### PR TITLE
Add Preview 2 Internet rooms and public lobby

### DIFF
--- a/MeleePad.xcodeproj/project.pbxproj
+++ b/MeleePad.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		AA0000000000000000000124 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000235 /* PrivacyInfo.xcprivacy */; };
 		AA0000000000000000000125 /* MeleePadControllerMapping.mm in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000236 /* MeleePadControllerMapping.mm */; };
 		AA0000000000000000000126 /* MeleePadOnlinePlayViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000238 /* MeleePadOnlinePlayViewController.mm */; };
+		AA0000000000000000000127 /* MeleePadPublicLobbyClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000240 /* MeleePadPublicLobbyClient.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -85,6 +86,8 @@
 		AA0000000000000000000237 /* MeleePadControllerMapping.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeleePadControllerMapping.h; sourceTree = "<group>"; };
 		AA0000000000000000000238 /* MeleePadOnlinePlayViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MeleePadOnlinePlayViewController.mm; sourceTree = "<group>"; };
 		AA0000000000000000000239 /* MeleePadOnlinePlayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeleePadOnlinePlayViewController.h; sourceTree = "<group>"; };
+		AA0000000000000000000240 /* MeleePadPublicLobbyClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MeleePadPublicLobbyClient.m; sourceTree = "<group>"; };
+		AA0000000000000000000241 /* MeleePadPublicLobbyClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeleePadPublicLobbyClient.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +150,8 @@
 				AA0000000000000000000210 /* MeleePadGameOverlay.h */,
 				AA0000000000000000000238 /* MeleePadOnlinePlayViewController.mm */,
 				AA0000000000000000000239 /* MeleePadOnlinePlayViewController.h */,
+				AA0000000000000000000240 /* MeleePadPublicLobbyClient.m */,
+				AA0000000000000000000241 /* MeleePadPublicLobbyClient.h */,
 				AA0000000000000000000205 /* Assets.xcassets */,
 				AA0000000000000000000214 /* Info.plist */,
 				AA0000000000000000000220 /* dev-config.plist */,
@@ -285,6 +290,7 @@
 				AA0000000000000000000102 /* MeleePadGameViewController.mm in Sources */,
 				AA0000000000000000000103 /* MeleePadGameOverlay.mm in Sources */,
 				AA0000000000000000000126 /* MeleePadOnlinePlayViewController.mm in Sources */,
+				AA0000000000000000000127 /* MeleePadPublicLobbyClient.m in Sources */,
 				AA0000000000000000000104 /* MeleePadSettings.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -356,7 +362,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				HEADER_SEARCH_PATHS = (
@@ -416,7 +422,7 @@
 				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				HEADER_SEARCH_PATHS = (

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ by scene and device; this image is evidence from one observed match, not a
 universal performance guarantee.*
 
 > [!IMPORTANT]
-> MeleePad v0.1.0 Preview 1 is the first completed developer preview. It is not
-> available through the App Store or TestFlight, and online play is not yet
-> reliable between Apple platforms. You must build the playable app locally and
-> supply your own supported game image. Performance and rendering still vary by
-> scene and device.
+> MeleePad v0.1.0 Preview 2 adds experimental private Internet rooms, Direct IP,
+> compatibility checks, and the development public-lobby UI. It is not an
+> online-play beta: there is no deployed public game browser, relay, automatic
+> matchmaking, ranked play, or Slippi rollback. The downloadable IPA is an
+> unsigned, module-free app shell and is **not playable as downloaded**. A
+> playable build must be generated locally from your own exact supported game
+> image. Performance and rendering still vary by scene and device.
 
 ## How MeleePad works
 
@@ -107,6 +109,23 @@ addresses, and data. Even another legitimate regional or revision build can
 differ at those locations. MeleePad currently validates and supports only the
 USA `GALE01` revision 0 image used to generate and test this module.
 
+The supported input is the original uncompressed USA disc image commonly
+described as Melee v1.00:
+
+| Property | Required value |
+|---|---|
+| Game | Super Smash Bros. Melee (USA) |
+| Game ID | `GALE01` |
+| Disc number | `0` |
+| Disc revision byte | `0` |
+| File format | Raw ISO/GCM, not RVZ, WIA, CISO, NKit, ZIP, or 7z |
+| Exact size | `1,459,978,240` bytes |
+| SHA-256 | `2393aadd346c23e3e44291e7bb7e16dbc4970bc703028261659a87cde9d90484` |
+
+Revision 1/v1.01, revision 2/v1.02, PAL, and Japanese images are not supported.
+Renaming another image to `GALE01.iso` does not make it compatible; the build
+and import paths verify its bytes.
+
 ### Does the repository or app include Melee?
 
 No. The repository contains no game image, extracted game assets, saves, or
@@ -116,24 +135,33 @@ extracts the data required by the runtime. The game data stays on your device.
 
 ### How do I install it?
 
-Preview 1 is published as
-[a source release](https://github.com/chrissotraidis/meleepad/releases/tag/v0.1.0-preview.1).
-There is no App Store or TestFlight build. A playable iPhone or iPad app must be
-built locally because its ARM64 game module is generated from the user's own
-supported disc image and is not a redistributable repository or release asset.
-Developers can build it on an Apple Silicon Mac with Xcode and sign it using
-their own Apple development account. Start with the
+The [Preview 2 prerelease](https://github.com/chrissotraidis/meleepad/releases/tag/v0.1.0-preview.2)
+contains source plus an unsigned, module-free IPA for inspection and
+signing-workflow development. There is no App Store or TestFlight build. The
+public IPA deliberately excludes the generated
+`gGALE01_recomp.dylib`; importing an ISO into that shell cannot create the
+ahead-of-time module on iOS, so the public IPA alone cannot play the game.
+
+A playable iPhone or iPad app must be built locally because its ARM64 game
+module is generated from the user's own supported disc image and is not a
+repository or release asset. Developers can build it on an Apple Silicon Mac
+with Xcode and sign it using their own Apple development account. Start with the
 [requirements](#requirements), follow the
 [physical-device build steps](#build-for-a-physical-iphone-or-ipad), and then
 complete [first-launch game-data import](#first-launch-on-iphone-or-ipad).
 
 ### Does multiplayer work?
 
-Not reliably across Apple platforms yet. One direct two-Mac match has completed,
-but Mac/iPad sessions currently stop at a synchronization safety check. Room
-codes, traversal, relay, public matchmaking, and a consumer-ready online flow
-are not implemented. The [Experimental multiplayer](#experimental-multiplayer)
-section explains exactly what exists and what remains.
+Yes, experimentally, in Preview 2. Private Room uses Dolphin's public traversal
+rendezvous to create an eight-character code; players still need to exchange
+that code with one another. Mac and iPad Simulator peers have hosted and joined
+in both directions and sustained synchronized play. Direct IP also remains
+available. There is no deployed public game browser or automatic matchmaking,
+and no MeleePad gameplay server or relay. Physical-device Internet matches,
+independent outside networks, complete cross-platform matches/rematches, NAT
+success rate, and failure recovery remain unverified. The
+[Experimental multiplayer](#experimental-multiplayer) section gives the exact
+boundary.
 
 ### What works on physical hardware today?
 
@@ -152,8 +180,8 @@ complete device acceptance matrix is still in progress.
 | macOS | Native Apple Silicon launcher and runner, Metal rendering, keyboard and controller profiles, matches, saves, and settings | Final display and worst-frame acceptance work remains |
 | iPhone and iPad | Native app shell, Metal gameplay, touch controls, controller mapping, More menu, exact-image import, persistent saves and settings, and diagnostic export | Serious water, reflection, and shadow rendering defects remain; the full visual, audio, controller, and lifecycle matrix has not passed |
 | Performance | A physical iPad can hold 59.9–60.0 FPS/VPS at 2x resolution during observed solo play | Preview 1 can fall to 46–57 FPS in heavier scenes under thermal pressure; results are scene- and device-specific |
-| Experimental multiplayer | Direct-IP fixed-delay transport, Host and Join lobby, compatibility fingerprinting, and one completed two-Mac direct match | Mac/iPad synchronization currently fails closed; reliable cross-platform matches, room codes, traversal, relay, and matchmaking are unavailable |
-| Distribution | v0.1.0 Preview 1 source release and locally built, locally signed development apps | No App Store or TestFlight build; the locally generated game module is not distributed |
+| Experimental multiplayer | Preview 2 fixed-delay Private Room and Direct IP transport, eight-character room codes, native Host/Join lobby, compatibility fingerprinting, and synchronized Mac/iPad Simulator runs in both host directions | No public matchmaking endpoint, physical-device/outside-network/full-match beta evidence, relay, or Slippi rollback |
+| Distribution | Preview 2 source plus an unsigned, module-free IPA shell; locally generated, locally signed playable apps | Public IPA is not playable as downloaded; no App Store or TestFlight build; the locally generated game module is not distributed |
 
 The combat-only right-stick mapping has passed a hands-on physical-iPad retest,
 including the required menu/gameplay behavior. The current evidence, remaining
@@ -173,10 +201,12 @@ To build MeleePad, you need:
 - Xcode 26.x;
 - CMake, Ninja, Git, ripgrep, and Python 3; and
 - your own legally obtained USA revision 0 Melee disc image (`GALE01`) in raw
-  ISO or GCM form.
+  ISO or GCM form: exactly 1,459,978,240 bytes with SHA-256
+  `2393aadd346c23e3e44291e7bb7e16dbc4970bc703028261659a87cde9d90484`.
 
-MeleePad supports that exact game revision. The preparation scripts validate
-the selected image and reject unsupported input.
+MeleePad supports that exact USA v1.00/revision-0 image only. The preparation
+scripts validate the size, hash, game ID, disc number, and revision, and reject
+unsupported or compressed input.
 
 ## Build from source
 
@@ -208,6 +238,22 @@ xcodebuild -project MeleePad.xcodeproj -scheme MeleePad \
   -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M5)' \
   CODE_SIGNING_ALLOWED=NO build
 ```
+
+Release maintainers can build the publishable module-free iPhoneOS shell and
+package it reproducibly with:
+
+```sh
+xcodebuild -project MeleePad.xcodeproj -scheme MeleePad \
+  -configuration Release -destination 'generic/platform=iOS' \
+  -derivedDataPath build/DerivedData-public \
+  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
+./scripts/package-public-ios-ipa.sh \
+  build/DerivedData-public/Build/Products/Release-iphoneos/MeleePad.app
+```
+
+The packager refuses game modules, game/save files, provisioning profiles,
+signatures, and private host paths. Its output remains an app shell; it does not
+replace the playable local-build process below.
 
 ### Build for a physical iPhone or iPad
 
@@ -277,8 +323,26 @@ physical-controller profiles are preserved.
 
 ## Experimental multiplayer
 
-**Online play is not ready for general use.** The current UI is a developer
-preview for direct connections, not a public multiplayer beta.
+**Online play is not ready for general use.** Preview 2 contains working
+private room codes, Direct IP, and a locally verified public-room browser. It
+is an engineering preview, not a deployed public multiplayer beta.
+
+### What a player can do in Preview 2
+
+1. Arrange a game with another MeleePad player outside the app.
+2. Confirm that both players use Preview 2 build 5, the exact supported
+   `GALE01` revision 0 image, and matching gameplay settings.
+3. The host opens **More (•••) → Online Play → Private Room → Host**.
+4. After the app displays an eight-character room code, the host sends it to
+   the other player through a trusted channel.
+5. The guest opens **Private Room → Join**, enters that code, and connects.
+6. Both players verify the compatibility state, mark Ready, and the host starts
+   the match.
+
+This flow depends on Dolphin's public traversal rendezvous being reachable.
+The code helps peers find each other; it is not a password, identity check, or
+end-to-end-encryption guarantee. There is no in-app list of strangers to play
+in the shipped configuration.
 
 ### How the current preview works
 
@@ -287,6 +351,10 @@ preview for direct connections, not a public multiplayer beta.
 - Both devices need the same MeleePad build, supported game revision, module,
   and compatible settings.
 - The transport uses fixed delay. It is not Slippi rollback netcode.
+- Gameplay is peer-to-peer over ENet after traversal introduction. MeleePad
+  does not host the match or stream the game.
+- There is no relay fallback. Some NAT or firewall combinations may fail even
+  when the room code resolves.
 - The joining player is assigned another GameCube controller port.
 - A synchronization mismatch stops the session instead of allowing the two
   games to continue in different states.
@@ -296,15 +364,40 @@ preview for direct connections, not a public multiplayer beta.
 | Test | Result |
 |---|---|
 | Two Macs using direct connection | One full match completed through results and lobby return, with saves unchanged |
-| Mac and iPad connection and synchronized start | The peers connect and begin together, then the session stops at the canonical-state synchronization gate |
+| Mac and iPad direct connection | Clean rebuilt peers sustained synchronized execution in both host directions beyond the old failure point |
 | iPhone multiplayer interaction | Compile coverage only; no completed device match |
-| Room-code or public-internet play | Not implemented or accepted |
+| Public Internet room code | Dolphin's live traversal service created/resolved fresh codes; Mac/iPad Simulator sustained about 4,700 rendered frames in each host direction |
+| Public room discovery | Local lobby service discovered a live Mac traversal host and authorized an iPad Simulator join; production service is not deployed |
 
-The current Mac/iPad failure is being investigated as a deterministic state
-difference. Until that is resolved, a private network, VPN, or forwarded port
-can improve reachability but **cannot** make cross-platform gameplay reliable.
-The exact evidence and restart point are recorded in the
-[paused B1 multiplayer goal loop](docs/NETPLAY-BETA-GOAL-LOOP.md).
+The earlier Mac/iPad canonical failure was stale-build contamination and did
+not reproduce after clean rebuilds; no timing tolerance or RAM exclusion was
+used. The stronger full-match and real-network acceptance work continues in
+the [multiplayer goal loop](docs/NETPLAY-BETA-GOAL-LOOP.md).
+
+### Private Room, Public Games, and Direct IP
+
+**Private Room** is the working Internet-room preview. It uses Dolphin's public
+traversal rendezvous to create an eight-character code, but MeleePad does not
+operate or guarantee that service. Players find one another elsewhere and
+exchange the code privately.
+
+**Public Games** is the future discovery/matchmaking layer. Its native UI has
+version-aware room cards, Host/Join, preset quick chat, and Hide/Report. A
+public list never contains the traversal code; only an authenticated,
+compatible Join response discloses it. The release has no configured production
+endpoint, so Public Games reports that it is unavailable instead of showing a
+fake or unsafe player population.
+
+**Direct IP** bypasses both discovery and traversal. It is intended for local
+networks and advanced testing. Across the Internet it may require UDP port
+forwarding or a trusted private VPN.
+
+The public browser needs a configured HTTPS MeleePad lobby endpoint. No such
+production endpoint is bundled or deployed yet, so release builds fail closed
+to the still-working Private Room and Direct IP paths. The local service and
+Simulator instructions are in
+[services/lobby/README.md](services/lobby/README.md); the remaining gates are
+in the [public lobby goal loop](docs/PUBLIC-LOBBY-GOAL-LOOP.md).
 
 ### Direct connection details for developers
 
@@ -323,12 +416,30 @@ testing across the public internet may require UDP port forwarding or a private
 VPN. The current gameplay channel is plaintext, so use it only with trusted
 people on a private test network. Do not expose it as a public service.
 
-MeleePad does not currently operate a traversal service and does not provide
-room codes, a public lobby, accounts, relay fallback, matchmaking, spectating,
-or ranked play. Dolphin's traversal protocol is the planned basis for private
-room codes after cross-platform determinism is proven. Slippi is an established
+MeleePad does not currently operate its own traversal service. Preview 2 uses
+Dolphin's public traversal service for room introduction and has no service
+guarantee, accounts, relay fallback, automatic matchmaking, spectating, or
+ranked play. The development discovery service only indexes compatible
+MeleePad traversal rooms and never proxies gameplay. Slippi is an established
 Melee-specific rollback and matchmaking system, but it is not a drop-in server
 for this build and would require a separate integration project.
+
+### Plan after Preview 2
+
+The next-preview plan is deliberately staged:
+
+1. deploy a supported HTTPS staging discovery service with durable moderation,
+   rate limits, monitoring, retention deletion, and rollback;
+2. finish full matches on physical Apple devices across independent networks,
+   including NAT, disconnect, backgrounding, save, input, audio, and thermal
+   coverage;
+3. run a small moderated production canary with operator and abuse-response
+   drills; and
+4. freeze one version/build/protocol tuple for the next preview, keeping Public
+   Games disabled if the service or moderation gate is incomplete.
+
+The detailed gates and stop rules are in the
+[public lobby goal loop](docs/PUBLIC-LOBBY-GOAL-LOOP.md).
 
 ### What is required before a beta claim
 

--- a/apple/ios/MeleePadCoreHost.h
+++ b/apple/ios/MeleePadCoreHost.h
@@ -31,12 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
  * synchronized boot data is installed and the netplay runtime has started. */
 - (void)beginNetplayHostingWithNickname:(NSString *)nickname
                                    port:(uint16_t)port
+                         usingTraversal:(BOOL)usingTraversal
                         automaticBuffer:(BOOL)automaticBuffer
                            bufferFrames:(NSUInteger)bufferFrames
                              completion:(void (^)(NSString *_Nullable error))completion;
 - (void)beginNetplayJoiningAddress:(NSString *)address
                           nickname:(NSString *)nickname
                               port:(uint16_t)port
+                    usingTraversal:(BOOL)usingTraversal
                    automaticBuffer:(BOOL)automaticBuffer
                       bufferFrames:(NSUInteger)bufferFrames
                         completion:(void (^)(NSString *_Nullable error))completion;

--- a/apple/ios/MeleePadCoreHost.mm
+++ b/apple/ios/MeleePadCoreHost.mm
@@ -489,6 +489,7 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
                      address:(NSString *)address
                     nickname:(NSString *)nickname
                         port:(uint16_t)port
+              usingTraversal:(BOOL)usingTraversal
              automaticBuffer:(BOOL)automaticBuffer
                 bufferFrames:(NSUInteger)bufferFrames
                   completion:(void (^)(NSString *_Nullable))completion {
@@ -537,6 +538,7 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
 
         moderngekko::frontend::NetplayOptions options;
         options.role = role;
+        options.use_traversal = usingTraversal;
         options.address = address.UTF8String ?: "";
         options.port = port;
         options.nickname = nickname.UTF8String ?: "Player";
@@ -566,11 +568,13 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
 
 - (void)beginNetplayHostingWithNickname:(NSString *)nickname
                                    port:(uint16_t)port
+                         usingTraversal:(BOOL)usingTraversal
                         automaticBuffer:(BOOL)automaticBuffer
                            bufferFrames:(NSUInteger)bufferFrames
                              completion:(void (^)(NSString *_Nullable))completion {
     [self beginNetplayWithRole:moderngekko::frontend::NetplayRole::Host
                        address:@"127.0.0.1" nickname:nickname port:port
+                usingTraversal:usingTraversal
                automaticBuffer:automaticBuffer bufferFrames:bufferFrames
                     completion:completion];
 }
@@ -578,11 +582,13 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
 - (void)beginNetplayJoiningAddress:(NSString *)address
                           nickname:(NSString *)nickname
                               port:(uint16_t)port
+                    usingTraversal:(BOOL)usingTraversal
                    automaticBuffer:(BOOL)automaticBuffer
                       bufferFrames:(NSUInteger)bufferFrames
                         completion:(void (^)(NSString *_Nullable))completion {
     [self beginNetplayWithRole:moderngekko::frontend::NetplayRole::Join
                        address:address nickname:nickname port:port
+                usingTraversal:usingTraversal
                automaticBuffer:automaticBuffer bufferFrames:bufferFrames
                     completion:completion];
 }
@@ -623,6 +629,7 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
             @"buffer": @(snapshot.buffer_frames),
             @"automaticBuffer": @(snapshot.adaptive_buffer),
             @"canStart": @(snapshot.can_start),
+            @"roomCode": snapshot.room_code.empty() ? @"" : @(snapshot.room_code.c_str()),
             @"status": snapshot.status.empty() ? @"" : @(snapshot.status.c_str()),
             @"error": snapshot.error.empty() ? @"" : @(snapshot.error.c_str()),
             @"connectionLost": @(snapshot.connection_lost),

--- a/apple/ios/MeleePadGameViewController.mm
+++ b/apple/ios/MeleePadGameViewController.mm
@@ -240,6 +240,7 @@ static NSUInteger MeleePadRegularFileCount(NSString *directory) {
                            gamepad:(GCExtendedGamepad *)gamepad;
 - (void)reconcileControllersForReason:(NSString *)reason;
 - (NSString *)resolvedImportTestPath:(NSString *)requestedPath;
+- (void)startAutomatedNetplayIfRequested;
 - (void)showGameDataSetupState;
 - (NSString *)meleePadSupportRoot;
 @end
@@ -265,6 +266,9 @@ static NSUInteger MeleePadRegularFileCount(NSString *directory) {
     MeleePadOnlinePlayViewController *_onlinePlayController;
     dispatch_source_t _onlinePlayPollTimer;
     BOOL _onlinePlaySessionRequested;
+    BOOL _automatedNetplay;
+    BOOL _automatedNetplayStartRequested;
+    BOOL _automatedNetplayRoomCodeReported;
 }
 
 - (BOOL)shouldAutorotate {
@@ -385,6 +389,72 @@ static NSUInteger MeleePadRegularFileCount(NSString *directory) {
     [self startGameIfProvisioned];
     [self startInputConsumer];
     [self observeControllers];
+    [self startAutomatedNetplayIfRequested];
+}
+
+- (void)startAutomatedNetplayIfRequested {
+#if TARGET_OS_SIMULATOR
+    NSDictionary<NSString *, NSString *> *environment = NSProcessInfo.processInfo.environment;
+    NSString *role = environment[@"MELEEPAD_NETPLAY_AUTO_ROLE"].lowercaseString;
+    if ([role isEqualToString:@"ui"]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self gameOverlayRequestsOnlinePlay:self->_overlay];
+        });
+        return;
+    }
+    if (![role isEqualToString:@"host"] && ![role isEqualToString:@"join"])
+        return;
+
+    NSString *nickname = environment[@"MELEEPAD_NETPLAY_AUTO_NICKNAME"] ?: @"Simulator";
+    NSString *address = environment[@"MELEEPAD_NETPLAY_AUTO_ADDRESS"] ?: @"127.0.0.1";
+    NSInteger requestedPort = [environment[@"MELEEPAD_NETPLAY_AUTO_PORT"] integerValue];
+    uint16_t port = requestedPort >= 1 && requestedPort <= UINT16_MAX
+        ? (uint16_t)requestedPort : 2626;
+    BOOL usingTraversal =
+        [environment[@"MELEEPAD_NETPLAY_AUTO_TRAVERSAL"] boolValue];
+    _automatedNetplay = YES;
+    _onlinePlaySessionRequested = YES;
+    MeleePadLog(@"netplay automation requested role=%@ mode=%@ port=%u", role,
+              usingTraversal ? @"internet-room" : @"direct", port);
+
+    __weak MeleePadGameViewController *weakSelf = self;
+    _coreHost.onNetplayMatchStarted = ^{
+        MeleePadGameViewController *strongSelf = weakSelf;
+        if (strongSelf == nil)
+            return;
+        MeleePadLog(@"netplay automation match started");
+        if (strongSelf->_onlinePlayPollTimer != nil) {
+            dispatch_source_cancel(strongSelf->_onlinePlayPollTimer);
+            strongSelf->_onlinePlayPollTimer = nil;
+        }
+    };
+    _coreHost.onNetplayMatchEnded = ^{
+        MeleePadLog(@"netplay automation match ended");
+    };
+
+    void (^completion)(NSString *) = ^(NSString *error) {
+        MeleePadGameViewController *strongSelf = weakSelf;
+        if (strongSelf == nil)
+            return;
+        if (error.length > 0) {
+            MeleePadLog(@"netplay automation failed: %@", error);
+            return;
+        }
+        [strongSelf->_coreHost setNetplayReady:YES];
+        [strongSelf startOnlinePlayPolling];
+    };
+    if ([role isEqualToString:@"host"]) {
+        [_coreHost beginNetplayHostingWithNickname:nickname port:port
+                                    usingTraversal:usingTraversal
+                                   automaticBuffer:YES bufferFrames:2
+                                         completion:completion];
+    } else {
+        [_coreHost beginNetplayJoiningAddress:address nickname:nickname port:port
+                               usingTraversal:usingTraversal
+                              automaticBuffer:YES bufferFrames:2
+                                    completion:completion];
+    }
+#endif
 }
 
 // Physical-device launches cannot refer to the host's /tmp. devicectl copies
@@ -1123,10 +1193,31 @@ static NSUInteger MeleePadRegularFileCount(NSString *directory) {
     __weak MeleePadGameViewController *weakSelf = self;
     dispatch_source_set_event_handler(_onlinePlayPollTimer, ^{
         MeleePadGameViewController *strongSelf = weakSelf;
-        if (strongSelf == nil || strongSelf->_onlinePlayController == nil)
+        if (strongSelf == nil ||
+            (strongSelf->_onlinePlayController == nil && !strongSelf->_automatedNetplay))
             return;
         [strongSelf->_coreHost pollNetplayWithCompletion:^(NSDictionary<NSString *,id> *snapshot) {
             MeleePadOnlinePlayViewController *lobby = strongSelf->_onlinePlayController;
+            if (strongSelf->_automatedNetplay) {
+                NSString *error = snapshot[@"error"];
+                if (error.length > 0)
+                    MeleePadLog(@"netplay automation session error: %@", error);
+                NSString *roomCode = snapshot[@"roomCode"];
+                BOOL traceRoomCode = [NSProcessInfo.processInfo.environment[
+                    @"MELEEPAD_NETPLAY_TRACE_ROOM_CODE"] boolValue];
+                if (traceRoomCode && !strongSelf->_automatedNetplayRoomCodeReported &&
+                    roomCode.length > 0) {
+                    strongSelf->_automatedNetplayRoomCodeReported = YES;
+                    MeleePadLog(@"netplay automation room code=%@", roomCode);
+                }
+                if ([snapshot[@"role"] isEqualToString:@"host"] &&
+                    [snapshot[@"canStart"] boolValue] &&
+                    !strongSelf->_automatedNetplayStartRequested) {
+                    strongSelf->_automatedNetplayStartRequested = YES;
+                    MeleePadLog(@"netplay automation starting synchronized match");
+                    [strongSelf->_coreHost requestNetplayStart];
+                }
+            }
             if (lobby == nil)
                 return;
             NSString *error = snapshot[@"error"];
@@ -1144,6 +1235,7 @@ static NSUInteger MeleePadRegularFileCount(NSString *directory) {
                        bufferFrames:[snapshot[@"buffer"] unsignedIntegerValue]
                     automaticBuffer:[snapshot[@"automaticBuffer"] boolValue]
                            canStart:[snapshot[@"canStart"] boolValue]
+                           roomCode:snapshot[@"roomCode"]
                              status:snapshot[@"status"]];
         }];
     });
@@ -1153,6 +1245,7 @@ static NSUInteger MeleePadRegularFileCount(NSString *directory) {
 - (void)onlinePlayViewController:(MeleePadOnlinePlayViewController *)controller
                      requestsHostWithNickname:(NSString *)nickname
                                          port:(uint16_t)port
+                                 internetRoom:(BOOL)internetRoom
                               automaticBuffer:(BOOL)automaticBuffer
                                  bufferFrames:(NSUInteger)bufferFrames {
     if (_coreHost == nil) {
@@ -1163,6 +1256,7 @@ static NSUInteger MeleePadRegularFileCount(NSString *directory) {
     [controller showConnectingWithMessage:@"Creating lobby…"];
     __weak MeleePadGameViewController *weakSelf = self;
     [_coreHost beginNetplayHostingWithNickname:nickname port:port
+                                usingTraversal:internetRoom
                                automaticBuffer:automaticBuffer
                                   bufferFrames:bufferFrames
                                     completion:^(NSString *error) {
@@ -1178,6 +1272,7 @@ static NSUInteger MeleePadRegularFileCount(NSString *directory) {
                      requestsJoinWithNickname:(NSString *)nickname
                                       address:(NSString *)address
                                          port:(uint16_t)port
+                                 internetRoom:(BOOL)internetRoom
                               automaticBuffer:(BOOL)automaticBuffer
                                  bufferFrames:(NSUInteger)bufferFrames {
     if (_coreHost == nil) {
@@ -1188,6 +1283,7 @@ static NSUInteger MeleePadRegularFileCount(NSString *directory) {
     [controller showConnectingWithMessage:@"Connecting to host…"];
     __weak MeleePadGameViewController *weakSelf = self;
     [_coreHost beginNetplayJoiningAddress:address nickname:nickname port:port
+                           usingTraversal:internetRoom
                           automaticBuffer:automaticBuffer
                              bufferFrames:bufferFrames
                                completion:^(NSString *error) {

--- a/apple/ios/MeleePadOnlinePlayViewController.h
+++ b/apple/ios/MeleePadOnlinePlayViewController.h
@@ -15,12 +15,14 @@ typedef NS_ENUM(NSInteger, MeleePadOnlinePlayRole) {
 - (void)onlinePlayViewController:(MeleePadOnlinePlayViewController *)controller
                      requestsHostWithNickname:(NSString *)nickname
                                          port:(uint16_t)port
+                                 internetRoom:(BOOL)internetRoom
                               automaticBuffer:(BOOL)automaticBuffer
                                  bufferFrames:(NSUInteger)bufferFrames;
 - (void)onlinePlayViewController:(MeleePadOnlinePlayViewController *)controller
                      requestsJoinWithNickname:(NSString *)nickname
                                       address:(NSString *)address
                                          port:(uint16_t)port
+                                 internetRoom:(BOOL)internetRoom
                               automaticBuffer:(BOOL)automaticBuffer
                                  bufferFrames:(NSUInteger)bufferFrames;
 - (void)onlinePlayViewController:(MeleePadOnlinePlayViewController *)controller
@@ -41,6 +43,7 @@ typedef NS_ENUM(NSInteger, MeleePadOnlinePlayRole) {
               bufferFrames:(NSUInteger)bufferFrames
            automaticBuffer:(BOOL)automaticBuffer
                   canStart:(BOOL)canStart
+                  roomCode:(nullable NSString *)roomCode
                     status:(nullable NSString *)status;
 - (void)showError:(NSString *)message;
 - (void)resetToSetup;

--- a/apple/ios/MeleePadOnlinePlayViewController.mm
+++ b/apple/ios/MeleePadOnlinePlayViewController.mm
@@ -1,4 +1,5 @@
 #import "MeleePadOnlinePlayViewController.h"
+#import "MeleePadPublicLobbyClient.h"
 
 #include <cmath>
 
@@ -6,69 +7,119 @@
 @end
 
 @implementation MeleePadOnlinePlayViewController {
+    UISegmentedControl *_connectionControl;
     UISegmentedControl *_roleControl;
     UITextField *_nicknameField;
     UITextField *_addressField;
     UITextField *_portField;
+    UILabel *_connectionHelp;
     UISwitch *_automaticBufferSwitch;
     UIStepper *_bufferStepper;
     UILabel *_bufferValueLabel;
     UIButton *_connectButton;
+    UIButton *_publicHostButton;
+    UIButton *_refreshButton;
+    UILabel *_publicStatusLabel;
+    UIStackView *_publicRoomsStack;
+    UIStackView *_publicStack;
+    UIStackView *_privateStack;
+    UIStackView *_bufferStack;
     UILabel *_stateLabel;
+    UILabel *_roomCodeLabel;
     UIStackView *_playersStack;
+    UIStackView *_messagesStack;
+    UIButton *_quickChatButton;
     UIButton *_readyButton;
     UIButton *_startButton;
     UIStackView *_setupStack;
     UIStackView *_lobbyStack;
+    MeleePadPublicLobbyClient *_publicLobbyClient;
     BOOL _localReady;
+    BOOL _publicHostPending;
+    BOOL _publicAutoJoinConsumed;
+    NSUInteger _lastMessageID;
+    NSTimeInterval _lastMessagePoll;
+    NSTimeInterval _lastHeartbeat;
 }
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.title = @"Experimental Multiplayer";
+    self.title = @"Online Play";
     self.view.backgroundColor = [UIColor colorWithRed:0.035 green:0.055 blue:0.10 alpha:1.0];
-
+    self.navigationController.navigationBar.tintColor = UIColor.whiteColor;
+    self.navigationController.navigationBar.titleTextAttributes = @{
+        NSForegroundColorAttributeName: UIColor.whiteColor,
+    };
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc]
-        initWithTitle:@"Cancel" style:UIBarButtonItemStylePlain
-               target:self action:@selector(cancel:)];
+        initWithTitle:@"Cancel" style:UIBarButtonItemStylePlain target:self action:@selector(cancel:)];
+    _publicLobbyClient = [MeleePadPublicLobbyClient new];
 
     UILabel *intro = [UILabel new];
-    intro.text = @"Direct Peer Connection";
+    intro.text = @"Play MeleePad Together";
     intro.textColor = UIColor.whiteColor;
     intro.font = [UIFont systemFontOfSize:24.0 weight:UIFontWeightBold];
-
     UILabel *detail = [UILabel new];
-    detail.text = @"Each device runs the same Melee match locally and exchanges controller input; the other player appears on another GameCube port. The host creates a direct lobby, the friend joins with the host's address, both mark Ready, and the host starts. There are no room codes or matchmaking servers yet, and complete matches are not yet reliable.";
+    detail.text = @"Find a compatible public game, share a private room code, or connect directly. The match still runs peer-to-peer through MeleePad's deterministic netplay.";
     detail.textColor = [UIColor colorWithWhite:0.82 alpha:1.0];
     detail.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightRegular];
     detail.numberOfLines = 0;
+
+    _connectionControl = [[UISegmentedControl alloc]
+        initWithItems:@[@"Public Games", @"Private Room", @"Direct IP"]];
+    _connectionControl.selectedSegmentIndex = 0;
+    _connectionControl.accessibilityLabel = @"Connection type";
+    [_connectionControl addTarget:self action:@selector(connectionChanged:)
+                 forControlEvents:UIControlEventValueChanged];
+    _nicknameField = [self textFieldWithPlaceholder:@"Nickname"];
+    _nicknameField.text = @"Player";
+    _nicknameField.textContentType = UITextContentTypeNickname;
+    _nicknameField.returnKeyType = UIReturnKeyDone;
+
+    UILabel *openGamesLabel = [UILabel new];
+    openGamesLabel.text = @"Open games";
+    openGamesLabel.textColor = UIColor.whiteColor;
+    openGamesLabel.font = [UIFont systemFontOfSize:18.0 weight:UIFontWeightBold];
+    _refreshButton = [self secondaryButtonWithTitle:@"Refresh" action:@selector(refreshPublicGames:)];
+    _refreshButton.accessibilityIdentifier = @"public-lobby-refresh";
+    UIStackView *publicHeader = [[UIStackView alloc]
+        initWithArrangedSubviews:@[openGamesLabel, _refreshButton]];
+    publicHeader.axis = UILayoutConstraintAxisHorizontal;
+    publicHeader.alignment = UIStackViewAlignmentCenter;
+    publicHeader.distribution = UIStackViewDistributionEqualSpacing;
+    _publicStatusLabel = [self mutedLabel];
+    _publicStatusLabel.accessibilityIdentifier = @"public-lobby-status";
+    _publicRoomsStack = [UIStackView new];
+    _publicRoomsStack.axis = UILayoutConstraintAxisVertical;
+    _publicRoomsStack.spacing = 10.0;
+    _publicHostButton = [self primaryButtonWithTitle:@"Host Public Game"
+                                              action:@selector(hostPublicGame:)];
+    _publicHostButton.accessibilityIdentifier = @"public-lobby-host";
+    _publicStack = [[UIStackView alloc] initWithArrangedSubviews:@[
+        publicHeader, _publicStatusLabel, _publicRoomsStack, _publicHostButton,
+    ]];
+    _publicStack.axis = UILayoutConstraintAxisVertical;
+    _publicStack.spacing = 12.0;
 
     _roleControl = [[UISegmentedControl alloc] initWithItems:@[@"Host", @"Join"]];
     _roleControl.selectedSegmentIndex = 0;
     _roleControl.accessibilityLabel = @"Host or join";
     [_roleControl addTarget:self action:@selector(roleChanged:)
            forControlEvents:UIControlEventValueChanged];
-
-    _nicknameField = [self textFieldWithPlaceholder:@"Nickname"];
-    _nicknameField.text = UIDevice.currentDevice.name.length > 0 ? @"Player" : @"Player";
-    _nicknameField.textContentType = UITextContentTypeNickname;
-    _nicknameField.returnKeyType = UIReturnKeyNext;
-
-    _addressField = [self textFieldWithPlaceholder:@"Host IP or hostname"];
+    _addressField = [self textFieldWithPlaceholder:@"8-character room code"];
     _addressField.keyboardType = UIKeyboardTypeURL;
     _addressField.autocapitalizationType = UITextAutocapitalizationTypeNone;
     _addressField.autocorrectionType = UITextAutocorrectionTypeNo;
     _addressField.returnKeyType = UIReturnKeyNext;
-
     _portField = [self textFieldWithPlaceholder:@"UDP port (default 2626)"];
     _portField.text = @"2626";
     _portField.keyboardType = UIKeyboardTypeNumberPad;
-
-    UILabel *portHelp = [UILabel new];
-    portHelp.text = @"2626 is Dolphin's standard direct-NetPlay UDP port, not a server address. Both players use the same value. Same Wi-Fi is simplest; internet hosts usually need UDP forwarding or a private VPN.";
-    portHelp.textColor = [UIColor colorWithWhite:0.68 alpha:1.0];
-    portHelp.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightRegular];
-    portHelp.numberOfLines = 0;
+    _connectionHelp = [self mutedLabel];
+    _connectButton = [self primaryButtonWithTitle:@"Host Private Room" action:@selector(connect:)];
+    _privateStack = [[UIStackView alloc] initWithArrangedSubviews:@[
+        _roleControl, _addressField, _portField, _connectionHelp, _connectButton,
+    ]];
+    _privateStack.axis = UILayoutConstraintAxisVertical;
+    _privateStack.spacing = 12.0;
 
     UILabel *automaticLabel = [UILabel new];
     automaticLabel.text = @"Automatic input buffer";
@@ -84,10 +135,9 @@
     automaticRow.axis = UILayoutConstraintAxisHorizontal;
     automaticRow.distribution = UIStackViewDistributionEqualSpacing;
     automaticRow.alignment = UIStackViewAlignmentCenter;
-
     _bufferValueLabel = [UILabel new];
     _bufferValueLabel.text = @"2 frames";
-    _bufferValueLabel.textColor = [UIColor colorWithWhite:0.80 alpha:1.0];
+    _bufferValueLabel.textColor = [UIColor colorWithWhite:0.50 alpha:1.0];
     _bufferValueLabel.font = [UIFont monospacedDigitSystemFontOfSize:14.0
                                                                weight:UIFontWeightRegular];
     _bufferStepper = [UIStepper new];
@@ -103,46 +153,59 @@
     bufferRow.axis = UILayoutConstraintAxisHorizontal;
     bufferRow.distribution = UIStackViewDistributionEqualSpacing;
     bufferRow.alignment = UIStackViewAlignmentCenter;
-
-    _connectButton = [self primaryButtonWithTitle:@"Host Game"
-                                           action:@selector(connect:)];
+    _bufferStack = [[UIStackView alloc] initWithArrangedSubviews:@[automaticRow, bufferRow]];
+    _bufferStack.axis = UILayoutConstraintAxisVertical;
+    _bufferStack.spacing = 10.0;
 
     _setupStack = [[UIStackView alloc] initWithArrangedSubviews:@[
-        _roleControl, _nicknameField, _addressField, _portField, portHelp,
-        automaticRow, bufferRow, _connectButton,
+        _connectionControl, _nicknameField, _publicStack, _privateStack, _bufferStack,
     ]];
     _setupStack.axis = UILayoutConstraintAxisVertical;
-    _setupStack.spacing = 12.0;
+    _setupStack.spacing = 14.0;
 
     UILabel *playersTitle = [UILabel new];
     playersTitle.text = @"Players";
     playersTitle.textColor = UIColor.whiteColor;
     playersTitle.font = [UIFont systemFontOfSize:18.0 weight:UIFontWeightBold];
-
     _playersStack = [UIStackView new];
     _playersStack.axis = UILayoutConstraintAxisVertical;
     _playersStack.spacing = 8.0;
-
-    _stateLabel = [UILabel new];
+    _roomCodeLabel = [UILabel new];
+    _roomCodeLabel.textColor = UIColor.whiteColor;
+    _roomCodeLabel.font = [UIFont monospacedSystemFontOfSize:18.0 weight:UIFontWeightSemibold];
+    _roomCodeLabel.numberOfLines = 0;
+    _roomCodeLabel.hidden = YES;
+    _stateLabel = [self mutedLabel];
     _stateLabel.text = @"Connecting…";
-    _stateLabel.textColor = [UIColor colorWithWhite:0.82 alpha:1.0];
-    _stateLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightRegular];
-    _stateLabel.numberOfLines = 0;
     _stateLabel.accessibilityIdentifier = @"online-play-status";
 
-    _readyButton = [self secondaryButtonWithTitle:@"Ready"
-                                            action:@selector(toggleReady:)];
-    _startButton = [self primaryButtonWithTitle:@"Start Match"
-                                          action:@selector(start:)];
+    UILabel *messagesTitle = [UILabel new];
+    messagesTitle.text = @"Quick chat";
+    messagesTitle.textColor = UIColor.whiteColor;
+    messagesTitle.font = [UIFont systemFontOfSize:18.0 weight:UIFontWeightBold];
+    _messagesStack = [UIStackView new];
+    _messagesStack.axis = UILayoutConstraintAxisVertical;
+    _messagesStack.spacing = 6.0;
+    _quickChatButton = [self secondaryButtonWithTitle:@"Send a message" action:@selector(noop:)];
+    _quickChatButton.menu = [self quickChatMenu];
+    _quickChatButton.showsMenuAsPrimaryAction = YES;
+    UIStackView *quickChatStack = [[UIStackView alloc]
+        initWithArrangedSubviews:@[messagesTitle, _messagesStack, _quickChatButton]];
+    quickChatStack.axis = UILayoutConstraintAxisVertical;
+    quickChatStack.spacing = 8.0;
+    quickChatStack.tag = 7001;
+    quickChatStack.hidden = YES;
+
+    _readyButton = [self secondaryButtonWithTitle:@"Ready" action:@selector(toggleReady:)];
+    _startButton = [self primaryButtonWithTitle:@"Start Match" action:@selector(start:)];
     _startButton.enabled = NO;
     UIStackView *lobbyActions = [[UIStackView alloc]
         initWithArrangedSubviews:@[_readyButton, _startButton]];
     lobbyActions.axis = UILayoutConstraintAxisHorizontal;
     lobbyActions.spacing = 12.0;
     lobbyActions.distribution = UIStackViewDistributionFillEqually;
-
     _lobbyStack = [[UIStackView alloc] initWithArrangedSubviews:@[
-        playersTitle, _playersStack, _stateLabel, lobbyActions,
+        playersTitle, _roomCodeLabel, _playersStack, _stateLabel, quickChatStack, lobbyActions,
     ]];
     _lobbyStack.axis = UILayoutConstraintAxisVertical;
     _lobbyStack.spacing = 12.0;
@@ -153,7 +216,6 @@
     content.axis = UILayoutConstraintAxisVertical;
     content.spacing = 14.0;
     content.translatesAutoresizingMaskIntoConstraints = NO;
-
     UIScrollView *scroll = [UIScrollView new];
     scroll.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:scroll];
@@ -172,7 +234,15 @@
         [content.widthAnchor constraintLessThanOrEqualToConstant:620.0],
         [content.centerXAnchor constraintEqualToAnchor:frame.centerXAnchor],
     ]];
-    [self roleChanged:_roleControl];
+    [self connectionChanged:_connectionControl];
+}
+
+- (UILabel *)mutedLabel {
+    UILabel *label = [UILabel new];
+    label.textColor = [UIColor colorWithWhite:0.72 alpha:1.0];
+    label.font = [UIFont systemFontOfSize:13.0 weight:UIFontWeightRegular];
+    label.numberOfLines = 0;
+    return label;
 }
 
 - (UITextField *)textFieldWithPlaceholder:(NSString *)placeholder {
@@ -216,57 +286,342 @@
     return button;
 }
 
+- (void)connectionChanged:(UISegmentedControl *)sender {
+    BOOL publicGames = sender.selectedSegmentIndex == 0;
+    _publicStack.hidden = !publicGames;
+    _privateStack.hidden = publicGames;
+    if (publicGames) {
+        if (_publicLobbyClient.isAvailable)
+            [self refreshPublicGames:nil];
+        else {
+            _publicStatusLabel.text = @"Public games are not configured in this build. Private rooms and Direct IP are available now.";
+            _publicHostButton.enabled = NO;
+        }
+        return;
+    }
+    [self roleChanged:_roleControl];
+}
+
 - (void)roleChanged:(UISegmentedControl *)sender {
     BOOL joining = sender.selectedSegmentIndex == MeleePadOnlinePlayRoleJoin;
+    BOOL privateRoom = _connectionControl.selectedSegmentIndex == 1;
     _addressField.hidden = !joining;
-    [_connectButton setTitle:(joining ? @"Join Game" : @"Host Game")
-                    forState:UIControlStateNormal];
+    _addressField.placeholder = privateRoom ? @"8-character room code" : @"Host IP or hostname";
+    _addressField.accessibilityLabel = _addressField.placeholder;
+    _portField.hidden = privateRoom;
+    _connectionHelp.text = privateRoom
+        ? @"Private rooms use Dolphin's public traversal service. Share the ephemeral room code only with people you trust."
+        : @"Direct IP uses UDP port 2626 by default. Internet hosts may need UDP forwarding or a private VPN.";
+    NSString *title = joining ? @"Join Game" : (privateRoom ? @"Host Private Room" : @"Host Direct Game");
     UIButtonConfiguration *configuration = _connectButton.configuration;
-    configuration.title = joining ? @"Join Game" : @"Host Game";
+    configuration.title = title;
     _connectButton.configuration = configuration;
 }
 
 - (void)bufferModeChanged:(UISwitch *)sender {
     _bufferStepper.enabled = !sender.on;
-    _bufferValueLabel.textColor = [UIColor colorWithWhite:(sender.on ? 0.50 : 0.80)
-                                                    alpha:1.0];
+    _bufferValueLabel.textColor = [UIColor colorWithWhite:(sender.on ? 0.50 : 0.80) alpha:1.0];
 }
 
 - (void)bufferChanged:(UIStepper *)sender {
-    _bufferValueLabel.text = [NSString stringWithFormat:@"%lu frames",
-        (unsigned long)llround(sender.value)];
+    _bufferValueLabel.text = [NSString stringWithFormat:@"%lu frames", (unsigned long)llround(sender.value)];
+}
+
+- (NSString *)validatedNickname {
+    NSString *nickname = [_nicknameField.text stringByTrimmingCharactersInSet:
+        NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    if (nickname.length == 0 || nickname.length > 20) {
+        [self showError:@"Enter a nickname of 1–20 letters, numbers, spaces, dots, dashes, or underscores."];
+        return nil;
+    }
+    NSCharacterSet *allowed = [NSCharacterSet characterSetWithCharactersInString:
+        @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ._-"];
+    if ([nickname rangeOfCharacterFromSet:allowed.invertedSet].location != NSNotFound) {
+        [self showError:@"That nickname contains an unsupported character."];
+        return nil;
+    }
+    return nickname;
+}
+
+- (NSUInteger)bufferFrames {
+    return (NSUInteger)llround(_bufferStepper.value);
+}
+
+- (void)refreshPublicGames:(id)sender {
+    (void)sender;
+    NSString *nickname = [self validatedNickname];
+    if (nickname.length == 0)
+        return;
+    _refreshButton.enabled = NO;
+    _publicStatusLabel.textColor = [UIColor colorWithWhite:0.72 alpha:1.0];
+    _publicStatusLabel.text = @"Finding compatible games…";
+    __weak MeleePadOnlinePlayViewController *weakSelf = self;
+    [_publicLobbyClient prepareWithNickname:nickname completion:^(NSDictionary *result, NSString *error) {
+        (void)result;
+        MeleePadOnlinePlayViewController *strongSelf = weakSelf;
+        if (strongSelf == nil)
+            return;
+        if (error.length > 0) {
+            strongSelf->_refreshButton.enabled = YES;
+            strongSelf->_publicStatusLabel.textColor = UIColor.systemRedColor;
+            strongSelf->_publicStatusLabel.text = error;
+            return;
+        }
+        [strongSelf->_publicLobbyClient fetchRoomsWithCompletion:^(NSDictionary *roomsResult,
+                                                                    NSString *roomsError) {
+            strongSelf->_refreshButton.enabled = YES;
+            if (roomsError.length > 0) {
+                strongSelf->_publicStatusLabel.textColor = UIColor.systemRedColor;
+                strongSelf->_publicStatusLabel.text = roomsError;
+                return;
+            }
+            NSArray *rooms = [roomsResult[@"rooms"] isKindOfClass:NSArray.class]
+                ? roomsResult[@"rooms"] : @[];
+            [strongSelf renderPublicRooms:rooms];
+        }];
+    }];
+}
+
+- (void)renderPublicRooms:(NSArray<NSDictionary<NSString *, id> *> *)rooms {
+    for (UIView *view in _publicRoomsStack.arrangedSubviews) {
+        [_publicRoomsStack removeArrangedSubview:view];
+        [view removeFromSuperview];
+    }
+    _publicStatusLabel.textColor = [UIColor colorWithWhite:0.72 alpha:1.0];
+    _publicStatusLabel.text = rooms.count == 0
+        ? @"No open games yet. Start one and it will appear here for compatible players."
+        : [NSString stringWithFormat:@"%lu open game%@ · room codes stay private until Join",
+            (unsigned long)rooms.count, rooms.count == 1 ? @"" : @"s"];
+    for (NSDictionary<NSString *, id> *room in rooms)
+        [_publicRoomsStack addArrangedSubview:[self cardForRoom:room]];
+
+    if (!_publicAutoJoinConsumed &&
+        [NSProcessInfo.processInfo.environment[@"MELEEPAD_PUBLIC_LOBBY_AUTO_JOIN_FIRST"]
+            isEqualToString:@"1"]) {
+        for (NSDictionary *room in rooms) {
+            if ([room[@"compatible"] boolValue] && [room[@"state"] isEqual:@"waiting"]) {
+                _publicAutoJoinConsumed = YES;
+                [self joinPublicRoom:room];
+                break;
+            }
+        }
+    }
+}
+
+- (UIView *)cardForRoom:(NSDictionary<NSString *, id> *)room {
+    NSString *host = [room[@"host"] isKindOfClass:NSString.class] ? room[@"host"] : @"Player";
+    BOOL compatible = [room[@"compatible"] boolValue];
+    BOOL waiting = [room[@"state"] isEqual:@"waiting"];
+    NSInteger players = [room[@"players"] integerValue];
+    NSInteger capacity = [room[@"capacity"] integerValue];
+    UILabel *hostLabel = [UILabel new];
+    hostLabel.text = host;
+    hostLabel.textColor = UIColor.whiteColor;
+    hostLabel.font = [UIFont systemFontOfSize:16.0 weight:UIFontWeightSemibold];
+    UILabel *badge = [UILabel new];
+    badge.text = compatible ? @"  Compatible  " : @"  Version mismatch  ";
+    badge.textColor = compatible ? UIColor.systemGreenColor : UIColor.systemOrangeColor;
+    badge.backgroundColor = [badge.textColor colorWithAlphaComponent:0.12];
+    badge.font = [UIFont systemFontOfSize:12.0 weight:UIFontWeightSemibold];
+    badge.layer.cornerRadius = 8.0;
+    badge.clipsToBounds = YES;
+    UIStackView *header = [[UIStackView alloc] initWithArrangedSubviews:@[hostLabel, badge]];
+    header.axis = UILayoutConstraintAxisHorizontal;
+    header.distribution = UIStackViewDistributionEqualSpacing;
+    header.alignment = UIStackViewAlignmentCenter;
+    UILabel *metadata = [self mutedLabel];
+    NSString *state = waiting ? @"Waiting" : @"In match";
+    metadata.text = [NSString stringWithFormat:@"%@ · %ld/%ld · %@\nMeleePad %@ (%@) · %@ %@",
+        room[@"region"] ?: @"auto", (long)players, (long)capacity, state,
+        room[@"app_version"] ?: @"?", room[@"build"] ?: @"?",
+        room[@"game_id"] ?: @"?", room[@"game_revision"] ?: @"?"];
+
+    UIButton *join = [self primaryButtonWithTitle:@"Join" action:@selector(noop:)];
+    join.enabled = compatible && waiting && players < capacity;
+    join.accessibilityIdentifier = [NSString stringWithFormat:@"join-public-room-%@", room[@"room_id"] ?: @""];
+    __weak MeleePadOnlinePlayViewController *weakSelf = self;
+    [join addAction:[UIAction actionWithHandler:^(__kindof UIAction *action) {
+        (void)action;
+        [weakSelf joinPublicRoom:room];
+    }] forControlEvents:UIControlEventTouchUpInside];
+    UIButton *more = [self secondaryButtonWithTitle:@"More" action:@selector(noop:)];
+    more.menu = [self moderationMenuForRoom:room];
+    more.showsMenuAsPrimaryAction = YES;
+    UIStackView *actions = [[UIStackView alloc] initWithArrangedSubviews:@[more, join]];
+    actions.axis = UILayoutConstraintAxisHorizontal;
+    actions.spacing = 8.0;
+    actions.distribution = UIStackViewDistributionFillEqually;
+    UIStackView *card = [[UIStackView alloc] initWithArrangedSubviews:@[header, metadata, actions]];
+    card.axis = UILayoutConstraintAxisVertical;
+    card.spacing = 10.0;
+    card.layoutMargins = UIEdgeInsetsMake(14, 14, 14, 14);
+    card.layoutMarginsRelativeArrangement = YES;
+    card.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.08];
+    card.layer.cornerRadius = 14.0;
+    return card;
+}
+
+- (UIMenu *)moderationMenuForRoom:(NSDictionary<NSString *, id> *)room {
+    __weak MeleePadOnlinePlayViewController *weakSelf = self;
+    UIAction *hide = [UIAction actionWithTitle:@"Hide Player"
+        image:[UIImage systemImageNamed:@"eye.slash"] identifier:nil
+        handler:^(__kindof UIAction *action) { (void)action; [weakSelf hidePublicRoom:room]; }];
+    UIAction *offensive = [UIAction actionWithTitle:@"Report Offensive Name"
+        image:[UIImage systemImageNamed:@"exclamationmark.bubble"]
+        identifier:nil handler:^(__kindof UIAction *action) {
+        (void)action; [weakSelf reportPublicRoom:room reason:@"offensive_name"];
+    }];
+    offensive.attributes = UIMenuElementAttributesDestructive;
+    UIAction *spam = [UIAction actionWithTitle:@"Report Spam"
+        image:[UIImage systemImageNamed:@"exclamationmark.triangle"]
+        identifier:nil handler:^(__kindof UIAction *action) {
+        (void)action; [weakSelf reportPublicRoom:room reason:@"spam"];
+    }];
+    spam.attributes = UIMenuElementAttributesDestructive;
+    return [UIMenu menuWithTitle:@"Safety" children:@[hide, offensive, spam]];
+}
+
+- (void)hidePublicRoom:(NSDictionary<NSString *, id> *)room {
+    [_publicLobbyClient hideSessionID:room[@"host_id"] completion:^(NSDictionary *result, NSString *error) {
+        (void)result;
+        if (error.length > 0) [self showError:error]; else [self refreshPublicGames:nil];
+    }];
+}
+
+- (void)reportPublicRoom:(NSDictionary<NSString *, id> *)room reason:(NSString *)reason {
+    [_publicLobbyClient reportSessionID:room[@"host_id"] roomID:room[@"room_id"] reason:reason
+        completion:^(NSDictionary *result, NSString *error) {
+        (void)result;
+        if (error.length > 0) [self showError:error]; else [self refreshPublicGames:nil];
+    }];
+}
+
+- (void)hostPublicGame:(id)sender {
+    (void)sender;
+    NSString *nickname = [self validatedNickname];
+    if (nickname.length == 0) return;
+    _publicHostButton.enabled = NO;
+    __weak MeleePadOnlinePlayViewController *weakSelf = self;
+    [_publicLobbyClient prepareWithNickname:nickname completion:^(NSDictionary *result, NSString *error) {
+        (void)result;
+        MeleePadOnlinePlayViewController *strongSelf = weakSelf;
+        strongSelf->_publicHostButton.enabled = YES;
+        if (error.length > 0) { [strongSelf showError:error]; return; }
+        strongSelf->_publicHostPending = YES;
+        [strongSelf showConnectingWithMessage:@"Opening a traversal room…"];
+        [strongSelf.delegate onlinePlayViewController:strongSelf
+                              requestsHostWithNickname:nickname port:2626 internetRoom:YES
+                               automaticBuffer:strongSelf->_automaticBufferSwitch.on
+                                  bufferFrames:[strongSelf bufferFrames]];
+    }];
+}
+
+- (void)joinPublicRoom:(NSDictionary<NSString *, id> *)room {
+    NSString *roomID = room[@"room_id"];
+    if (roomID.length == 0) return;
+    _publicStatusLabel.text = [NSString stringWithFormat:@"Joining %@…", room[@"host"] ?: @"game"];
+    [_publicLobbyClient joinRoomID:roomID completion:^(NSDictionary *result, NSString *error) {
+        if (error.length > 0) {
+            self->_publicStatusLabel.textColor = UIColor.systemRedColor;
+            self->_publicStatusLabel.text = error;
+            return;
+        }
+        NSString *code = result[@"traversal_code"];
+        if (code.length != 8) {
+            self->_publicStatusLabel.text = @"The lobby did not return a valid room code.";
+            return;
+        }
+        [self showConnectingWithMessage:@"Connecting to the public game…"];
+        [self.delegate onlinePlayViewController:self requestsJoinWithNickname:[self validatedNickname]
+                                        address:code.lowercaseString port:2626 internetRoom:YES
+                                automaticBuffer:self->_automaticBufferSwitch.on
+                                   bufferFrames:[self bufferFrames]];
+    }];
 }
 
 - (void)connect:(id)sender {
     (void)sender;
     [self.view endEditing:YES];
-    NSString *nickname = [_nicknameField.text stringByTrimmingCharactersInSet:
-        NSCharacterSet.whitespaceAndNewlineCharacterSet];
-    NSString *portText = [_portField.text stringByTrimmingCharactersInSet:
-        NSCharacterSet.whitespaceAndNewlineCharacterSet];
-    NSInteger portValue = portText.integerValue;
-    if (nickname.length == 0 || nickname.length > 20 || portValue < 1 || portValue > UINT16_MAX) {
-        [self showError:@"Enter a nickname of 1–20 characters and a valid UDP port."];
+    NSString *nickname = [self validatedNickname];
+    if (nickname.length == 0) return;
+    BOOL internetRoom = _connectionControl.selectedSegmentIndex == 1;
+    NSInteger portValue = internetRoom ? 2626 : _portField.text.integerValue;
+    if (!internetRoom && (portValue < 1 || portValue > UINT16_MAX)) {
+        [self showError:@"Enter a valid UDP port."];
         return;
     }
-    NSUInteger frames = (NSUInteger)llround(_bufferStepper.value);
     if (_roleControl.selectedSegmentIndex == MeleePadOnlinePlayRoleHost) {
         [self.delegate onlinePlayViewController:self requestsHostWithNickname:nickname
-                                          port:(uint16_t)portValue
-                               automaticBuffer:_automaticBufferSwitch.on
-                                  bufferFrames:frames];
+            port:(uint16_t)portValue internetRoom:internetRoom
+            automaticBuffer:_automaticBufferSwitch.on bufferFrames:[self bufferFrames]];
         return;
     }
     NSString *address = [_addressField.text stringByTrimmingCharactersInSet:
         NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    if (internetRoom) address = address.lowercaseString;
     if (address.length == 0) {
-        [self showError:@"Enter the host address shared by your friend."];
+        [self showError:internetRoom ? @"Enter the eight-character room code shared by the host."
+                                      : @"Enter the host address shared by your friend."];
+        return;
+    }
+    NSCharacterSet *nonHex = [[NSCharacterSet characterSetWithCharactersInString:@"0123456789abcdef"] invertedSet];
+    if (internetRoom && (address.length != 8 ||
+        [address rangeOfCharacterFromSet:nonHex].location != NSNotFound)) {
+        [self showError:@"Room codes contain exactly eight hexadecimal characters."];
         return;
     }
     [self.delegate onlinePlayViewController:self requestsJoinWithNickname:nickname
-                                    address:address port:(uint16_t)portValue
-                            automaticBuffer:_automaticBufferSwitch.on
-                               bufferFrames:frames];
+        address:address port:(uint16_t)portValue internetRoom:internetRoom
+        automaticBuffer:_automaticBufferSwitch.on bufferFrames:[self bufferFrames]];
+}
+
+- (UIMenu *)quickChatMenu {
+    NSArray<NSArray<NSString *> *> *messages = @[
+        @[@"Hello!", @"hello"], @[@"Ready when you are.", @"ready"],
+        @[@"One moment, please.", @"moment"], @[@"Good luck—have fun!", @"good_luck"],
+        @[@"Good games!", @"good_games"], @[@"Rematch?", @"rematch"],
+    ];
+    NSMutableArray<UIAction *> *actions = [NSMutableArray array];
+    __weak MeleePadOnlinePlayViewController *weakSelf = self;
+    for (NSArray<NSString *> *message in messages) {
+        [actions addObject:[UIAction actionWithTitle:message[0] image:nil identifier:nil
+            handler:^(__kindof UIAction *action) {
+            (void)action; [weakSelf sendQuickMessage:message[1]];
+        }]];
+    }
+    return [UIMenu menuWithTitle:@"Preset messages" children:actions];
+}
+
+- (void)sendQuickMessage:(NSString *)kind {
+    [_publicLobbyClient sendQuickMessage:kind completion:^(NSDictionary *result, NSString *error) {
+        (void)result;
+        if (error.length > 0) self->_stateLabel.text = error;
+        else [self pollPublicMessagesIfNeeded:YES];
+    }];
+}
+
+- (void)pollPublicMessagesIfNeeded:(BOOL)force {
+    if (_publicLobbyClient.activeRoomID.length == 0) return;
+    NSTimeInterval now = NSDate.timeIntervalSinceReferenceDate;
+    if (!force && now - _lastMessagePoll < 2.0) return;
+    _lastMessagePoll = now;
+    [_publicLobbyClient fetchMessagesAfter:_lastMessageID completion:^(NSDictionary *result, NSString *error) {
+        if (error.length > 0) return;
+        NSArray *messages = [result[@"messages"] isKindOfClass:NSArray.class] ? result[@"messages"] : @[];
+        for (NSDictionary *message in messages) {
+            self->_lastMessageID = MAX(self->_lastMessageID, [message[@"id"] unsignedIntegerValue]);
+            UILabel *row = [self mutedLabel];
+            row.textColor = UIColor.whiteColor;
+            row.text = [NSString stringWithFormat:@"%@: %@", message[@"sender"] ?: @"Player",
+                message[@"text"] ?: @""];
+            [self->_messagesStack addArrangedSubview:row];
+            while (self->_messagesStack.arrangedSubviews.count > 6) {
+                UIView *oldest = self->_messagesStack.arrangedSubviews.firstObject;
+                [self->_messagesStack removeArrangedSubview:oldest];
+                [oldest removeFromSuperview];
+            }
+        }
+    }];
 }
 
 - (void)toggleReady:(id)sender {
@@ -280,58 +635,98 @@
 
 - (void)start:(id)sender {
     (void)sender;
+    [_publicLobbyClient heartbeatInGame:YES completion:nil];
     [self.delegate onlinePlayViewControllerRequestsStart:self];
 }
 
 - (void)cancel:(id)sender {
     (void)sender;
+    [self closePublicPresence];
     [self.delegate onlinePlayViewControllerRequestsCancel:self];
 }
+
+- (void)closePublicPresence {
+    _publicHostPending = NO;
+    if (_publicLobbyClient.activeRoomID.length == 0) return;
+    [_publicLobbyClient closeHostedRoomWithCompletion:nil];
+    [_publicLobbyClient leaveActiveRoomWithCompletion:nil];
+}
+
+- (void)noop:(id)sender { (void)sender; }
 
 - (void)showConnectingWithMessage:(NSString *)message {
     _setupStack.hidden = YES;
     _lobbyStack.hidden = NO;
     _readyButton.hidden = YES;
     _startButton.hidden = YES;
+    _roomCodeLabel.hidden = YES;
+    _roomCodeLabel.text = @"";
     _stateLabel.textColor = [UIColor colorWithWhite:0.82 alpha:1.0];
     _stateLabel.text = message;
 }
 
 - (void)showLobbyForRole:(MeleePadOnlinePlayRole)role
-                   players:(NSArray<NSDictionary<NSString *,id> *> *)players
-              bufferFrames:(NSUInteger)bufferFrames
-           automaticBuffer:(BOOL)automaticBuffer
-                  canStart:(BOOL)canStart
-                    status:(NSString *)status {
+                 players:(NSArray<NSDictionary<NSString *,id> *> *)players
+            bufferFrames:(NSUInteger)bufferFrames
+         automaticBuffer:(BOOL)automaticBuffer
+                canStart:(BOOL)canStart
+                roomCode:(NSString *)roomCode
+                  status:(NSString *)status {
     _setupStack.hidden = YES;
     _lobbyStack.hidden = NO;
     _readyButton.hidden = NO;
     _startButton.hidden = role != MeleePadOnlinePlayRoleHost;
     _startButton.enabled = canStart;
+    BOOL publicRoom = _publicLobbyClient.activeRoomID.length > 0 || _publicHostPending;
+    _roomCodeLabel.hidden = publicRoom || roomCode.length == 0;
+    _roomCodeLabel.text = (!publicRoom && roomCode.length > 0)
+        ? [NSString stringWithFormat:@"Room code: %@", roomCode] : @"";
     _stateLabel.textColor = [UIColor colorWithWhite:0.82 alpha:1.0];
     _stateLabel.text = status.length > 0 ? status : [NSString stringWithFormat:
         @"Input buffer: %lu frame%@%@", (unsigned long)bufferFrames,
         bufferFrames == 1 ? @"" : @"s", automaticBuffer ? @" (automatic)" : @""];
-
     for (UIView *view in _playersStack.arrangedSubviews) {
         [_playersStack removeArrangedSubview:view];
         [view removeFromSuperview];
     }
     for (NSDictionary<NSString *, id> *player in players) {
-        NSString *name = player[@"name"] ?: @"Player";
-        NSNumber *ping = player[@"ping"] ?: @0;
-        NSString *controller = player[@"controller"] ?: @"No controller";
-        BOOL compatible = [player[@"compatible"] boolValue];
-        BOOL ready = [player[@"ready"] boolValue];
         UILabel *row = [UILabel new];
         row.numberOfLines = 2;
         row.textColor = UIColor.whiteColor;
         row.font = [UIFont systemFontOfSize:15.0 weight:UIFontWeightSemibold];
         row.text = [NSString stringWithFormat:@"%@  ·  %@ ms  ·  %@\nCompatibility: %@  ·  %@",
-            name, ping, controller, compatible ? @"Match" : @"Mismatch",
-            ready ? @"Ready" : @"Not ready"];
+            player[@"name"] ?: @"Player", player[@"ping"] ?: @0,
+            player[@"controller"] ?: @"No controller",
+            [player[@"compatible"] boolValue] ? @"Match" : @"Mismatch",
+            [player[@"ready"] boolValue] ? @"Ready" : @"Not ready"];
         row.accessibilityLabel = row.text;
         [_playersStack addArrangedSubview:row];
+    }
+    UIStackView *quickChatStack = (UIStackView *)[_lobbyStack viewWithTag:7001];
+    quickChatStack.hidden = !publicRoom;
+    if (_publicHostPending && roomCode.length == 8) {
+        _publicHostPending = NO;
+        [_publicLobbyClient publishRoomWithTraversalCode:roomCode region:@"auto"
+            completion:^(NSDictionary *result, NSString *error) {
+            (void)result;
+            if (error.length > 0) {
+                self->_stateLabel.textColor = UIColor.systemRedColor;
+                self->_stateLabel.text = [NSString stringWithFormat:
+                    @"Connected privately, but public listing failed: %@", error];
+                return;
+            }
+            self->_stateLabel.text = @"Public game listed. Waiting for a compatible player…";
+            self->_lastHeartbeat = NSDate.timeIntervalSinceReferenceDate;
+            [self pollPublicMessagesIfNeeded:YES];
+        }];
+    }
+    if (_publicLobbyClient.activeRoomID.length > 0) {
+        NSTimeInterval now = NSDate.timeIntervalSinceReferenceDate;
+        if (now - _lastHeartbeat >= 15.0) {
+            _lastHeartbeat = now;
+            [_publicLobbyClient heartbeatInGame:NO completion:nil];
+        }
+        [self pollPublicMessagesIfNeeded:NO];
     }
 }
 
@@ -343,32 +738,30 @@
         _readyButton.hidden = YES;
         _startButton.hidden = YES;
     } else {
-        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Experimental Multiplayer"
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Online Play"
             message:message preferredStyle:UIAlertControllerStyleAlert];
-        [alert addAction:[UIAlertAction actionWithTitle:@"OK"
-            style:UIAlertActionStyleDefault handler:nil]];
+        [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
         [self presentViewController:alert animated:YES completion:nil];
     }
 }
 
 - (void)resetToSetup {
+    [self closePublicPresence];
     _localReady = NO;
+    _lastMessageID = 0;
+    _lastMessagePoll = 0;
+    _lastHeartbeat = 0;
     _setupStack.hidden = NO;
     _lobbyStack.hidden = YES;
     UIButtonConfiguration *configuration = _readyButton.configuration;
     configuration.title = @"Ready";
     _readyButton.configuration = configuration;
+    [self connectionChanged:_connectionControl];
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
-    if (textField == _nicknameField && !_addressField.hidden)
-        [_addressField becomeFirstResponder];
-    else if (textField == _nicknameField)
-        [_portField becomeFirstResponder];
-    else if (textField == _addressField)
-        [_portField becomeFirstResponder];
-    else
-        [textField resignFirstResponder];
+    if (textField == _addressField && !_portField.hidden) [_portField becomeFirstResponder];
+    else [textField resignFirstResponder];
     return YES;
 }
 

--- a/apple/ios/MeleePadPublicLobbyClient.h
+++ b/apple/ios/MeleePadPublicLobbyClient.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^MeleePadLobbyResult)(NSDictionary<NSString *, id> *_Nullable result,
+                                    NSString *_Nullable error);
+
+@interface MeleePadPublicLobbyClient : NSObject
+
+@property(nonatomic, readonly, getter=isAvailable) BOOL available;
+@property(nonatomic, readonly, nullable) NSString *activeRoomID;
+@property(nonatomic, readonly, nullable) NSString *localSessionID;
+
+- (instancetype)init;
+- (void)prepareWithNickname:(NSString *)nickname completion:(MeleePadLobbyResult)completion;
+- (void)fetchRoomsWithCompletion:(MeleePadLobbyResult)completion;
+- (void)publishRoomWithTraversalCode:(NSString *)traversalCode
+                              region:(NSString *)region
+                          completion:(MeleePadLobbyResult)completion;
+- (void)heartbeatInGame:(BOOL)inGame completion:(nullable MeleePadLobbyResult)completion;
+- (void)joinRoomID:(NSString *)roomID completion:(MeleePadLobbyResult)completion;
+- (void)leaveActiveRoomWithCompletion:(nullable MeleePadLobbyResult)completion;
+- (void)closeHostedRoomWithCompletion:(nullable MeleePadLobbyResult)completion;
+- (void)fetchMessagesAfter:(NSUInteger)messageID completion:(MeleePadLobbyResult)completion;
+- (void)sendQuickMessage:(NSString *)kind completion:(MeleePadLobbyResult)completion;
+- (void)hideSessionID:(NSString *)sessionID completion:(MeleePadLobbyResult)completion;
+- (void)reportSessionID:(NSString *)sessionID
+                 roomID:(NSString *)roomID
+                 reason:(NSString *)reason
+             completion:(MeleePadLobbyResult)completion;
+
+@end
+
+FOUNDATION_EXPORT NSString *const MeleePadPublicLobbyProtocol;
+
+NS_ASSUME_NONNULL_END

--- a/apple/ios/MeleePadPublicLobbyClient.m
+++ b/apple/ios/MeleePadPublicLobbyClient.m
@@ -1,0 +1,283 @@
+#import "MeleePadPublicLobbyClient.h"
+
+#import <TargetConditionals.h>
+
+NSString *const MeleePadPublicLobbyProtocol = @"moderngekko-netplay-8";
+
+@implementation MeleePadPublicLobbyClient {
+    NSURL *_baseURL;
+    NSURLSession *_session;
+    NSString *_token;
+    NSString *_nickname;
+    NSString *_activeRoomID;
+    NSString *_localSessionID;
+    BOOL _hosting;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self == nil)
+        return nil;
+
+    NSString *configured = NSProcessInfo.processInfo.environment[@"MELEEPAD_LOBBY_BASE_URL"];
+    if (configured.length == 0)
+        configured = [NSBundle.mainBundle objectForInfoDictionaryKey:@"MeleePadLobbyBaseURL"];
+    NSURL *candidate = configured.length > 0 ? [NSURL URLWithString:configured] : nil;
+    BOOL secure = [candidate.scheme.lowercaseString isEqualToString:@"https"];
+#if TARGET_OS_SIMULATOR
+    BOOL loopback = [candidate.scheme.lowercaseString isEqualToString:@"http"] &&
+        ([candidate.host isEqualToString:@"127.0.0.1"] ||
+         [candidate.host isEqualToString:@"localhost"]);
+#else
+    BOOL loopback = NO;
+#endif
+    if (candidate != nil && (secure || loopback)) {
+        _baseURL = candidate;
+        NSURLSessionConfiguration *configuration =
+            NSURLSessionConfiguration.ephemeralSessionConfiguration;
+        configuration.timeoutIntervalForRequest = 8.0;
+        configuration.timeoutIntervalForResource = 12.0;
+        configuration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+        configuration.HTTPCookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
+        _session = [NSURLSession sessionWithConfiguration:configuration];
+    }
+    return self;
+}
+
+- (BOOL)isAvailable {
+    return _baseURL != nil;
+}
+
+- (NSString *)activeRoomID {
+    return _activeRoomID;
+}
+
+- (NSString *)localSessionID {
+    return _localSessionID;
+}
+
+- (void)prepareWithNickname:(NSString *)nickname completion:(MeleePadLobbyResult)completion {
+    if (!self.available) {
+        [self complete:completion result:nil
+                 error:@"Public games are not configured in this build. Private rooms still work."];
+        return;
+    }
+    if (_token.length > 0 && [_nickname isEqualToString:nickname]) {
+        [self complete:completion result:@{@"ready": @YES} error:nil];
+        return;
+    }
+    NSString *version = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"]
+        ?: @"unknown";
+    NSString *build = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"]
+        ?: @"unknown";
+    NSDictionary *body = @{
+        @"display_name": nickname,
+        @"app_version": version,
+        @"build": build,
+        @"protocol": MeleePadPublicLobbyProtocol,
+        @"game_id": @"GALE01",
+        @"game_revision": @"r0",
+    };
+    __weak MeleePadPublicLobbyClient *weakSelf = self;
+    [self requestMethod:@"POST" path:@"/v1/sessions" body:body authenticated:NO
+             completion:^(NSDictionary *result, NSString *error) {
+        MeleePadPublicLobbyClient *strongSelf = weakSelf;
+        if (strongSelf != nil && error.length == 0) {
+            strongSelf->_token = result[@"token"];
+            strongSelf->_localSessionID = result[@"session_id"];
+            strongSelf->_nickname = [nickname copy];
+        }
+        [strongSelf complete:completion result:result error:error];
+    }];
+}
+
+- (void)fetchRoomsWithCompletion:(MeleePadLobbyResult)completion {
+    [self requestMethod:@"GET" path:@"/v1/rooms" body:nil authenticated:YES
+             completion:completion];
+}
+
+- (void)publishRoomWithTraversalCode:(NSString *)traversalCode
+                              region:(NSString *)region
+                          completion:(MeleePadLobbyResult)completion {
+    NSDictionary *body = @{
+        @"traversal_code": traversalCode.lowercaseString,
+        @"region": region.length > 0 ? region : @"auto",
+    };
+    __weak MeleePadPublicLobbyClient *weakSelf = self;
+    [self requestMethod:@"POST" path:@"/v1/rooms" body:body authenticated:YES
+             completion:^(NSDictionary *result, NSString *error) {
+        MeleePadPublicLobbyClient *strongSelf = weakSelf;
+        if (strongSelf != nil && error.length == 0) {
+            strongSelf->_activeRoomID = result[@"room_id"];
+            strongSelf->_hosting = YES;
+        }
+        [strongSelf complete:completion result:result error:error];
+    }];
+}
+
+- (void)heartbeatInGame:(BOOL)inGame completion:(MeleePadLobbyResult)completion {
+    if (_activeRoomID.length == 0) {
+        [self complete:completion result:@{@"ok": @NO} error:nil];
+        return;
+    }
+    NSString *path = _hosting
+        ? [NSString stringWithFormat:@"/v1/rooms/%@/heartbeat", _activeRoomID]
+        : [NSString stringWithFormat:@"/v1/rooms/%@/members/me/heartbeat", _activeRoomID];
+    NSDictionary *body = _hosting
+        ? @{@"state": inGame ? @"in_game" : @"waiting"} : @{};
+    [self requestMethod:@"PUT" path:path body:body authenticated:YES completion:completion];
+}
+
+- (void)joinRoomID:(NSString *)roomID completion:(MeleePadLobbyResult)completion {
+    NSString *path = [NSString stringWithFormat:@"/v1/rooms/%@/join", roomID];
+    __weak MeleePadPublicLobbyClient *weakSelf = self;
+    [self requestMethod:@"POST" path:path body:@{} authenticated:YES
+             completion:^(NSDictionary *result, NSString *error) {
+        MeleePadPublicLobbyClient *strongSelf = weakSelf;
+        if (strongSelf != nil && error.length == 0) {
+            strongSelf->_activeRoomID = result[@"room_id"];
+            strongSelf->_hosting = NO;
+        }
+        [strongSelf complete:completion result:result error:error];
+    }];
+}
+
+- (void)leaveActiveRoomWithCompletion:(MeleePadLobbyResult)completion {
+    if (_activeRoomID.length == 0 || _hosting) {
+        _activeRoomID = nil;
+        [self complete:completion result:@{@"ok": @YES} error:nil];
+        return;
+    }
+    NSString *roomID = [_activeRoomID copy];
+    NSString *path = [NSString stringWithFormat:@"/v1/rooms/%@/members/me", roomID];
+    __weak MeleePadPublicLobbyClient *weakSelf = self;
+    [self requestMethod:@"DELETE" path:path body:nil authenticated:YES
+             completion:^(NSDictionary *result, NSString *error) {
+        MeleePadPublicLobbyClient *strongSelf = weakSelf;
+        if (error.length == 0)
+            strongSelf->_activeRoomID = nil;
+        [strongSelf complete:completion result:result error:error];
+    }];
+}
+
+- (void)closeHostedRoomWithCompletion:(MeleePadLobbyResult)completion {
+    if (_activeRoomID.length == 0 || !_hosting) {
+        [self complete:completion result:@{@"ok": @YES} error:nil];
+        return;
+    }
+    NSString *path = [NSString stringWithFormat:@"/v1/rooms/%@", _activeRoomID];
+    __weak MeleePadPublicLobbyClient *weakSelf = self;
+    [self requestMethod:@"DELETE" path:path body:nil authenticated:YES
+             completion:^(NSDictionary *result, NSString *error) {
+        MeleePadPublicLobbyClient *strongSelf = weakSelf;
+        if (error.length == 0) {
+            strongSelf->_activeRoomID = nil;
+            strongSelf->_hosting = NO;
+        }
+        [strongSelf complete:completion result:result error:error];
+    }];
+}
+
+- (void)fetchMessagesAfter:(NSUInteger)messageID completion:(MeleePadLobbyResult)completion {
+    if (_activeRoomID.length == 0) {
+        [self complete:completion result:@{@"messages": @[]} error:nil];
+        return;
+    }
+    NSString *path = [NSString stringWithFormat:@"/v1/rooms/%@/messages?after=%lu",
+        _activeRoomID, (unsigned long)messageID];
+    [self requestMethod:@"GET" path:path body:nil authenticated:YES completion:completion];
+}
+
+- (void)sendQuickMessage:(NSString *)kind completion:(MeleePadLobbyResult)completion {
+    if (_activeRoomID.length == 0) {
+        [self complete:completion result:nil error:@"Join a public room first."];
+        return;
+    }
+    NSString *path = [NSString stringWithFormat:@"/v1/rooms/%@/messages", _activeRoomID];
+    [self requestMethod:@"POST" path:path body:@{@"kind": kind}
+          authenticated:YES completion:completion];
+}
+
+- (void)hideSessionID:(NSString *)sessionID completion:(MeleePadLobbyResult)completion {
+    [self requestMethod:@"POST" path:@"/v1/blocks"
+                   body:@{@"session_id": sessionID}
+          authenticated:YES completion:completion];
+}
+
+- (void)reportSessionID:(NSString *)sessionID
+                 roomID:(NSString *)roomID
+                 reason:(NSString *)reason
+             completion:(MeleePadLobbyResult)completion {
+    [self requestMethod:@"POST" path:@"/v1/reports"
+                   body:@{
+                       @"session_id": sessionID,
+                       @"room_id": roomID,
+                       @"reason": reason,
+                   }
+          authenticated:YES completion:completion];
+}
+
+- (void)requestMethod:(NSString *)method
+                  path:(NSString *)path
+                  body:(NSDictionary *)body
+         authenticated:(BOOL)authenticated
+            completion:(MeleePadLobbyResult)completion {
+    if (!self.available) {
+        [self complete:completion result:nil error:@"Public lobby unavailable."];
+        return;
+    }
+    if (authenticated && _token.length == 0) {
+        [self complete:completion result:nil error:@"Refresh the public lobby to reconnect."];
+        return;
+    }
+    NSURL *URL = [NSURL URLWithString:path relativeToURL:_baseURL];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
+    request.HTTPMethod = method;
+    request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+    [request setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    if (authenticated)
+        [request setValue:[@"Bearer " stringByAppendingString:_token]
+       forHTTPHeaderField:@"Authorization"];
+    if (body != nil) {
+        NSError *serializationError = nil;
+        NSData *data = [NSJSONSerialization dataWithJSONObject:body options:0
+                                                        error:&serializationError];
+        if (data == nil || data.length > 8 * 1024) {
+            [self complete:completion result:nil error:@"The lobby request was invalid."];
+            return;
+        }
+        request.HTTPBody = data;
+        [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
+    }
+    NSURLSessionDataTask *task = [_session dataTaskWithRequest:request
+        completionHandler:^(NSData *data, NSURLResponse *response, NSError *networkError) {
+        NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)response;
+        NSDictionary *JSON = data.length > 0
+            ? [NSJSONSerialization JSONObjectWithData:data options:0 error:nil] : nil;
+        NSString *message = nil;
+        if (networkError != nil) {
+            message = @"The public lobby could not be reached. Private rooms still work.";
+        } else if (HTTPResponse.statusCode < 200 || HTTPResponse.statusCode >= 300) {
+            NSDictionary *errorObject = [JSON[@"error"] isKindOfClass:NSDictionary.class]
+                ? JSON[@"error"] : nil;
+            message = [errorObject[@"message"] isKindOfClass:NSString.class]
+                ? errorObject[@"message"] : @"The public lobby request failed.";
+        } else if (![JSON isKindOfClass:NSDictionary.class]) {
+            message = @"The public lobby returned an invalid response.";
+        }
+        [self complete:completion result:JSON error:message];
+    }];
+    [task resume];
+}
+
+- (void)complete:(MeleePadLobbyResult)completion
+           result:(NSDictionary *)result
+            error:(NSString *)error {
+    if (completion == nil)
+        return;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        completion(result, error);
+    });
+}
+
+@end

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -6186,3 +6186,104 @@ Append-only execution ledger. Claims are limited to observed evidence.
   canonical sequence 6780/frame 120; do not repeat B0 or the passing two-Mac
   live-combat control.
 - Evidence: `docs/artifacts/2026-09-03/g9-netplay-beta-stop-handoff.md`.
+
+## 2026-09-03 — NET-299 public Internet room vertical slice
+
+- Recheck current upstream services. Dolphin's default traversal hostname and
+  UDP ports remain in mainline, the public lobby returned active sessions, and
+  fresh eight-character codes were issued and resolved during the retained
+  runs. Slippi remains active but is not a drop-in protocol/service for this
+  static-recomp client.
+- Add bounded 1 MiB MEM1 region hashes and signed timebase delta diagnostics,
+  then rebuild every iOS and Mac artifact cleanly. The old frame-120
+  `timebase,ram` failure no longer reproduces without any semantic/tolerance
+  change; classify it as stale-build contamination.
+- Pass direct iPad-host/Mac-join and reverse-host sessions beyond 3,500–4,700
+  rendered frames at approximately 60 FPS with no canonical mismatch.
+- Add ModernGekko patch 0020 for public-traversal room hosting/joining, room-code
+  snapshots, runner flags, and exact traversal status. Keep the local host
+  client direct while the server owns Dolphin's traversal socket.
+- Make Internet Room the native default, show/validate the eight-character
+  code, retain Direct IP, and state that codes are locators rather than
+  passwords or end-to-end encryption. Visually verify the Release iPad
+  Simulator form and repair its dark navigation title.
+- Pass public-service Mac-host/iPad-join and iPad-host/Mac-join synchronized
+  sessions for roughly 4,700 rendered frames each with no mismatch or
+  disconnect. Do not retain the ephemeral codes or IP addresses.
+- Decision: Internet play is possible in the retained MeleePad-to-MeleePad
+  Simulator/Mac test. Keep the beta/release claim closed pending full matches,
+  physical devices, independent networks/NAT matrix, lifecycle/error coverage,
+  security/privacy, and a supported service-operations decision.
+- Evidence: `docs/artifacts/2026-09-03/g9-public-internet-room-pass.md`.
+
+## 2026-09-03 — NET-300 public lobby development vertical slice
+
+- Research current Apple user-generated-content safety requirements, OWASP
+  real-time messaging controls, and Dolphin's public index implementation.
+- Choose preset quick chat instead of arbitrary anonymous free text; require
+  report/hide, filtered display names, exact compatibility, bounded inputs,
+  rate limits, expiry, secret-safe logs, and code disclosure only after Join.
+- Add a dependency-free local JSON lobby service and an ephemeral native HTTPS
+  client. Plain HTTP is accepted only for a loopback Simulator endpoint.
+- Add Public Games beside preserved Private Room and Direct IP modes. Render
+  tasteful version-aware cards, Host/Join, quick chat, and Safety actions.
+- Pass ten service tests, focused contracts, and the iPad Simulator build.
+- Complete a live Mac-host/iPad-Simulator discovery and authorized traversal
+  join through the local service; both endpoints appear compatible at 54 ms.
+- Catch the guest reservation expiring during the live session. Add
+  authenticated member heartbeats, reproduce past the original 20-second
+  window, and visibly deliver a preset `Hello!` message in the joined lobby.
+- Reverse the direction: publish from the native iPad Host Public Game flow,
+  discover and authorize from a Mac client, join through Dolphin traversal,
+  then prove host Cancel removes the room immediately.
+- Decision: accept the development vertical slice. Keep public availability
+  and beta claims closed because no production endpoint, durable moderation,
+  operations, physical-device, or independent-network gate has passed.
+- Evidence: `docs/artifacts/2026-09-03/public-lobby-vertical-slice.md`.
+
+## 2026-09-03 — NET-301 build 5 physical-iPad test deployment
+
+- Extend the public-lobby goal loop with four release phases: supported HTTPS
+  staging, independent-network physical acceptance, a moderated production
+  canary, and one frozen next-preview candidate.
+- Increment the unreleased build from 4 to 5 so public-room compatibility can
+  distinguish it from the prior device installation.
+- Rebuild the current ModernGekko device core and GALE01 module, then produce a
+  signed Release app using the existing `com.ssbmpad.SsbmPad` identity.
+- Back up the connected iPad Pro's GC save, Dolphin configuration, and app
+  preferences. Install build 5 in place without uninstalling or resetting its
+  data container.
+- Read the container back before launch: the save, configuration, and
+  preferences are byte-identical, and both the GALE01 ISO and 1,214 extracted
+  files remain. Launch build 5, verify the process and installed version, then
+  read the save back again and confirm it is still byte-identical.
+- Decision: hand build 5 to physical testing. Keep gameplay, physical Internet
+  match, and public-service claims open; no production lobby endpoint is
+  configured or deployed.
+- Evidence:
+  `docs/artifacts/2026-09-03/build5-physical-ipad-install.md`.
+
+## 2026-09-03 — NET-302 Preview 2 public package boundary
+
+- Rewrite the README around the actual Preview 2 product boundary: working
+  Private Room codes, Direct IP, disabled-without-service Public Games, fixed
+  delay, no relay or matchmaking, exact compatibility, and the staged roadmap.
+- Document the sole supported game input as raw USA GALE01 revision 0/v1.00,
+  1,459,978,240 bytes, SHA-256
+  `2393aadd346c23e3e44291e7bb7e16dbc4970bc703028261659a87cde9d90484`.
+- Audit the ignored local Preview 1 IPA and confirm it contains the
+  user-generated GALE01 module. Recheck GitHub and confirm that Preview 1 has
+  zero release assets and `main` contains no IPA or generated module; nothing
+  unsafe was public or required deletion.
+- Add a fail-closed public packager. It refuses any app containing the generated
+  module, game/save data, provisioning profile, signature, private key/cert, or
+  local host path, and removes the development configuration from the shell.
+- Produce the module-free unsigned Preview 2 IPA twice from a fresh ARM64
+  iPhoneOS build. The files are byte-identical, pass ZIP/bundle inspection, and
+  have SHA-256
+  `797a4d9c218650bd6f7377f07d798d5f06ff46abcfee33c8cdbe44248a552519`.
+- Feed the module-bearing private app to the public packager and retain its
+  expected refusal.
+- Decision: publish only source plus the clearly labelled module-free unsigned
+  app shell. Keep the playable generated-module IPA private.
+- Evidence: `docs/artifacts/2026-09-03/preview2-public-package.md`.

--- a/docs/NETPLAY-BETA-GOAL-LOOP.md
+++ b/docs/NETPLAY-BETA-GOAL-LOOP.md
@@ -1,14 +1,16 @@
 # MeleePad Online Play with Friends beta loop
 
-Status: paused at B1 (2026-09-03 stop checkpoint)
+Status: active at B1/B2 acceptance; public B3/B4 vertical slice proven (2026-09-03)
 Written: 2026-09-02  
 Supersedes: `NETPLAY-GOAL-LOOP.md`  
 Companion architecture: `NETPLAY-FEASIBILITY.md`
 
-Work may resume from B1 without repeating B0 or the passing two-Mac control.
-The current app remains **Experimental Multiplayer / Direct Connection
-Preview**; “Online Play with Friends (Beta)” is still the acceptance claim
-earned only by B10.
+The clean cross-platform rebuild no longer reproduces the old frame-120
+failure, and public Dolphin traversal now creates and resolves room codes in
+both Mac/iPad Simulator host directions. Resume at complete-match and lifecycle
+acceptance without repeating the transport vertical slice. The current work is
+still an engineering preview; “Online Play with Friends (Beta)” remains the
+claim earned only by B10.
 
 ## Goal
 
@@ -66,17 +68,17 @@ matchmaking, a public lobby, spectating, or anonymous pairing.
 | GameCube packet mapping | exact payload regressions | pass |
 | Headless session owner | two repeated lifecycle cycles | pass |
 | Two-Mac direct match | full match, results, lobby return, unchanged saves | pass |
-| Native iPad form | Host/Join/direct address/ready/start/cancel | partial |
-| Mac/iPad gameplay | begins together, stops around frames 6,180/6,240 | fail |
+| Native iPad form | Internet room/direct selection, host/join/code/ready/start/cancel | partial |
+| Mac/iPad gameplay | synchronized direct and public-room runs in both host directions | partial |
 | iPhone interaction | compile coverage only | missing |
-| Room-code client | Dolphin source exists but is not in `NetplaySession` | missing |
-| Traversal service | pinned CC0 source exists; nothing operated by MeleePad | missing |
+| Room-code client | `NetplaySession` host/join vertical slice works | partial |
+| Traversal service | Dolphin public service works in retained test; no MeleePad-operated endpoint | partial |
 | Relay | no implementation or measured need decision | missing |
 | Real internet/device beta | no evidence | missing |
 
-The current iPad form is an engineering panel. It puts Host/Join around direct
-address fields and tells users that room codes come later. It must not be
-promoted or cosmetically relabelled as the beta.
+The current iPad form is an engineering preview backed by a real room-code
+path, not a fake action. It still lacks the complete home/lobby/failure,
+accessibility, physical-device, and lifecycle evidence required for beta.
 
 The current desync diagnostic is also not a canonical state proof. Dolphin
 calls `SendTimeBase()` from the CPU-thread Pixel Engine finish event, not the

--- a/docs/PUBLIC-LOBBY-DESIGN.md
+++ b/docs/PUBLIC-LOBBY-DESIGN.md
@@ -1,0 +1,110 @@
+# MeleePad public lobby design
+
+Status: implemented development vertical slice; not deployed
+Date: 2026-09-03
+
+## Product outcome
+
+Players should be able to open Online Play, see real MeleePad rooms, understand
+compatibility before tapping Join, exchange enough coordination to start a
+match, and enter the existing traversal-backed netplay session without sharing
+an IP address or finding a code on another service.
+
+The first public lobby is intentionally small:
+
+```text
+Online Play
+
+Public Games   Private Room   Direct IP
+
+Open games                                      Refresh
+┌─────────────────────────────────────────────────────┐
+│ Player · Asia                         Compatible    │
+│ Waiting · 1/2 · MeleePad 0.1.0 (4) · GALE01 r0    │
+│                                              Join   │
+└─────────────────────────────────────────────────────┘
+
+Host Public Game
+```
+
+After joining, the normal player/ready/start lobby remains authoritative.
+Coordination uses six preset quick-chat messages: Hello, Ready, One moment,
+Good luck, Good games, and Rematch. There is no public free-text field.
+
+## Architecture
+
+```text
+iPhone / iPad / Mac
+        │ HTTPS JSON: discover, authorize join, quick chat
+        ▼
+MeleePad lobby service
+        │ returns traversal code only after compatible join
+        ▼
+Dolphin public traversal rendezvous
+        │ introduces peers; does not relay gameplay
+        ▼
+MeleePad host ◀──── encrypted? no; fixed-delay ENet ────▶ MeleePad guest
+```
+
+The discovery service never receives ROMs, extracted files, modules, saves,
+controller input, or gameplay packets. It stores ephemeral lobby metadata only.
+The existing netplay handshake remains the final compatibility authority.
+
+## Compatibility and room cards
+
+Every anonymous two-hour lobby session declares:
+
+- MeleePad marketing version and build;
+- ModernGekko netplay protocol;
+- game ID and game revision.
+
+Room listings show those values and an explicit compatibility result. An
+incompatible room remains visible so the player understands why the lobby may
+look sparse, but Join is disabled and the service refuses code disclosure.
+The gameplay handshake still verifies the stronger game/module/settings
+fingerprint after peers connect.
+
+## Security and privacy decisions
+
+- No accounts in this slice. The service issues cryptographically random,
+  short-lived bearer tokens and stores only their SHA-256 hashes.
+- Public listings never contain traversal codes or IP addresses. Join returns
+  a code only to a compatible authenticated session.
+- Hosts and joined guests heartbeat every 15 seconds; stale rooms expire after
+  45 seconds. Initial Join reservations expire after 20 seconds unless the
+  connected guest renews presence.
+- Request bodies are JSON allow-lists capped at 8 KiB. Rooms, reports, message
+  history, request rate, and quick-chat rate are bounded.
+- Messaging is preset quick-chat, not arbitrary anonymous chat. Display names
+  are restricted and filtered server-side.
+- Room menus provide Hide and Report. Reports also hide the player immediately.
+- Application diagnostics exclude IPs, tokens, room codes, and message bodies.
+- Production requires HTTPS, edge connection/rate limits, durable report
+  storage, health monitoring, restart supervision, and a published abuse
+  contact. The local server deliberately does not pretend those exist.
+
+Apple's current App Review Guideline 1.2 requires filtering, reporting,
+blocking, and published contact information for user-generated content, and
+explicitly covers random or anonymous chat. OWASP additionally recommends
+authenticated per-message authorization, strict validation, message-size and
+rate limits, idle expiry, and secret-safe logging. Preset quick-chat reduces
+the initial moderation surface without blocking basic match coordination.
+
+References:
+
+- https://developer.apple.com/app-store/review/guidelines/#user-generated-content
+- https://developer.apple.com/news/?id=d75yllv4
+- https://cheatsheetseries.owasp.org/cheatsheets/WebSocket_Security_Cheat_Sheet.html
+- https://github.com/dolphin-emu/netplay-index
+- https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/UICommon/NetPlayIndex.cpp
+
+## Acceptance boundary
+
+The development slice is complete when service tests pass, the native public
+lobby can create/list/join a room against the local service, quick-chat and
+report/hide work, the traversal code stays absent from list responses, and a
+Simulator screenshot verifies the visible hierarchy.
+
+Production remains blocked on deployment authority, persistent moderation,
+operational controls, independent-network/physical-device testing, NAT success
+measurement, and the broader netplay beta gates.

--- a/docs/PUBLIC-LOBBY-GOAL-LOOP.md
+++ b/docs/PUBLIC-LOBBY-GOAL-LOOP.md
@@ -1,0 +1,111 @@
+# MeleePad public lobby goal loop
+
+Status: development vertical slice complete; production service not deployed
+Started: 2026-09-03
+
+Current Preview 2 candidate: `0.1.0` build 5 is installed and running on the
+physical iPad, with its game data and save preserved. This proves deployment
+readiness for device testing only; the physical Internet-match gate remains
+open. The public IPA is an unsigned module-free shell and does not expand that
+claim.
+
+## Goal
+
+Let a player open Online Play, see compatible public MeleePad rooms, safely
+coordinate with another player, and enter the existing traversal-backed match
+without exchanging an IP address or room code out of band.
+
+## Definition of done
+
+The public lobby is release-ready only when one unchanged build proves:
+
+1. room cards show host, region, occupancy, state, app version/build, game
+   revision, and a clear compatibility result;
+2. public list responses never disclose IP addresses or traversal codes, and
+   Join returns a code only to an authenticated, compatible player;
+3. Host, Refresh, Join, Hide, Report, preset quick chat, Ready, Start, leave,
+   expiry, full-room, incompatible-room, and service-outage paths converge on
+   understandable native UI states;
+4. arbitrary anonymous messages are impossible; names are filtered and
+   reports/blocks have durable moderation handling and a published contact;
+5. production traffic uses HTTPS with edge limits, persistent storage,
+   monitoring, restart supervision, backups, and secret-safe logs;
+6. two physical Apple devices on independent networks find one another and
+   finish a five-minute match, results, rematch, and clean exit;
+7. NAT success, latency, disconnect recovery, backgrounding, and Wi-Fi loss
+   meet the wider netplay beta acceptance matrix; and
+8. release diagnostics contain no bearer token, traversal code, IP address,
+   message content, save, or game data.
+
+## Completed development slice
+
+- Dependency-free JSON service with ephemeral bearer sessions, hashed tokens,
+  exact compatibility gates, bounded storage, rate limits, room heartbeats,
+  join reservations, quick chat, hide, report, and a health check.
+- Native UIKit public-room browser integrated beside Private Room and Direct
+  IP, using the existing MeleePad visual language and netplay owner.
+- Simulator-only loopback configuration; physical builds reject plaintext
+  service URLs.
+- Ten service tests plus source/build checks pass.
+- A local service room containing a live Dolphin traversal code was discovered
+  by the iPad Simulator. Join disclosed the code only after authorization and
+  connected it to a Mac host; both appeared compatible in the native lobby.
+  Guest presence renewed beyond the initial reservation and quick chat still
+  delivered afterward.
+
+## Iteration loop
+
+For each remaining gate:
+
+1. choose the smallest missing production or device claim;
+2. write a fail-first service, source, or live acceptance check;
+3. make the narrowest change that preserves private rooms and Direct IP;
+4. test failure and abuse paths before the happy path;
+5. run the unchanged candidate on independent endpoints;
+6. retain redacted evidence and update status; and
+7. stop widening the feature if the stronger claim did not pass.
+
+Next gate: choose and authorize a production service owner/domain, then replace
+the in-memory report/room store with a durable operational deployment. Until
+that passes, the UI remains a development feature and must not imply a live
+public player population.
+
+## Roadmap to the next preview
+
+### P1 — supported staging service
+
+- Select the service owner, region, domain, privacy contact, and abuse contact.
+- Put the API behind HTTPS and edge connection/rate limits.
+- Replace in-memory rooms, blocks, and reports with bounded durable storage;
+  keep traversal codes and bearer tokens out of logs and backups.
+- Add migrations, health/ready checks, restart supervision, metrics, alerting,
+  retention deletion, and a tested rollback.
+- Configure staging only in an internal build and prove outage/error copy.
+
+### P2 — physical Internet acceptance
+
+- Run iPad-host/Mac-join, Mac-host/iPad-join, iPad/iPhone, and reverse-device
+  directions on genuinely independent networks.
+- Complete five-minute matches through results, rematch, and clean leave while
+  checking saves, touch/controller input, audio, thermals, and diagnostics.
+- Exercise full, stale, incompatible, blocked, reported, backgrounded, Wi-Fi-
+  lost, host-lost, and service-unavailable paths on the unchanged candidate.
+- Record NAT success by network type; if it is below 90%, decide on a relay or
+  explicitly narrow the preview instead of hiding failures.
+
+### P3 — moderated production canary
+
+- Complete privacy/security review and App Review Guideline 1.2 support copy.
+- Deploy a small canary, monitor join success and abuse reports, and verify
+  operators can remove rooms/identities without retaining gameplay data.
+- Promote the same endpoint/configuration only after rollback, alerting,
+  deletion, and moderation drills pass.
+
+### P4 — next release preview
+
+- Freeze one version/build/protocol tuple and reject every mismatch visibly.
+- Re-run repository, signing, package, installation, lifecycle, and physical
+  gameplay gates from the frozen candidate.
+- Publish only claims earned by retained evidence. Keep Public Games disabled
+  if the supported service or moderation gate is not ready; Private Room and
+  Direct IP remain the safe fallback.

--- a/docs/RELEASE-NOTES-PREVIEW-2.md
+++ b/docs/RELEASE-NOTES-PREVIEW-2.md
@@ -1,0 +1,62 @@
+# MeleePad v0.1.0 Preview 2
+
+Preview 2 makes MeleePad's first working Internet-room path available as an
+experimental developer preview.
+
+## Highlights
+
+- Private Room can create and join eight-character codes through Dolphin's
+  public traversal rendezvous.
+- Direct IP remains available for local-network and advanced testing.
+- The native Online Play screen now includes compatibility-aware Public Games,
+  Private Room, and Direct IP modes.
+- The development public-lobby service implements bounded rooms, version gates,
+  preset quick chat, heartbeats, hide/report controls, and secret-safe logging.
+- Cross-platform Mac/iPad Simulator sessions connected through public traversal
+  in both host directions and sustained roughly 4,700 rendered frames without a
+  canonical mismatch or disconnect.
+- The signed build-5 candidate was installed over build 4 on a physical iPad,
+  launched successfully, and preserved the existing game data, configuration,
+  preferences, and GCI save.
+
+## What online play does and does not provide
+
+Private Room is usable only after players find one another elsewhere and share
+the generated code. The match runs peer-to-peer with fixed input delay; this is
+not Slippi rollback, a streamed game, or a MeleePad-hosted gameplay server.
+Room codes are locators, not passwords or an end-to-end-encryption guarantee.
+There is no relay fallback, so some NAT/firewall combinations may fail.
+
+Public Games is a development vertical slice, not a live matchmaking service.
+No production MeleePad discovery endpoint is configured or deployed in this
+release, so the app fails closed and keeps Private Room and Direct IP available.
+
+Physical-device Internet matches, independent-network NAT coverage, complete
+cross-platform matches/rematches, lifecycle recovery, and the public-service
+operations/moderation gates remain open.
+
+## IPA and game-data boundary
+
+The attached
+`MeleePad-v0.1.0-preview.2-module-free-unsigned.ipa` is an unsigned ARM64 app
+shell for iOS/iPadOS 16 or later. It is **not playable as downloaded**. It does
+not contain Super Smash Bros. Melee, extracted Nintendo data, saves, signing
+material, or the locally generated `gGALE01_recomp.dylib` game module.
+
+A playable app must be built locally on an Apple Silicon Mac from the user's
+own legally obtained exact supported disc image and signed with the user's own
+Apple development identity.
+
+Supported image:
+
+- Super Smash Bros. Melee (USA), original v1.00;
+- game ID `GALE01`, disc 0, revision byte 0;
+- raw ISO/GCM, exactly 1,459,978,240 bytes; and
+- SHA-256
+  `2393aadd346c23e3e44291e7bb7e16dbc4970bc703028261659a87cde9d90484`.
+
+Revision 1/v1.01, revision 2/v1.02, PAL, Japanese, compressed, and modified
+images are unsupported.
+
+Public IPA SHA-256:
+`797a4d9c218650bd6f7377f07d798d5f06ff46abcfee33c8cdbe44248a552519`

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,5 +1,46 @@
 # meleepad status
 
+## 2026-09-03 — Preview 2 release contract
+
+Preview 2 packages the current networking work as version `0.1.0`, build `5`.
+It includes Private Room codes backed by Dolphin's public traversal rendezvous,
+Direct IP, strict compatibility/desync handling, and the native Public Games
+development UI. Public Games remains disabled without a configured production
+HTTPS discovery endpoint; there is no automatic matchmaking, relay fallback,
+ranked play, or Slippi rollback.
+
+The public asset is deliberately named
+`MeleePad-v0.1.0-preview.2-module-free-unsigned.ipa`. It is an unsigned ARM64
+iPhoneOS 16+ app shell, not a playable bundled game. The reproducible package
+has SHA-256
+`797a4d9c218650bd6f7377f07d798d5f06ff46abcfee33c8cdbe44248a552519`
+and excludes the user-generated GALE01 module, game data, saves, signing
+material, development paths, and local configuration. Playable builds still
+require local generation from the exact supported GALE01 USA revision-0 image.
+
+## 2026-09-03 — Build 5 installed on the physical iPad for testing
+
+The signed `0.1.0` build 5 candidate is installed in place over
+build 4 on the connected iPad Pro, and launches successfully. The install kept
+the existing `com.ssbmpad.SsbmPad` identity so it reused the established app
+container instead of creating a second installation.
+
+Before installation, the mutable GC save, configuration, and preferences were
+copied to a local temporary backup. A readback before first launch showed the
+save, every configuration file, and preferences were byte-identical; the
+1,459,978,240-byte GALE01 image and all 1,214 extracted game files remained in
+the container. A second save readback after launch was also byte-identical.
+The installed-app record reports version `0.1.0`, build `5`, and the MeleePad
+process is running.
+
+The complete repository gate and strict signature verification pass. This is
+installation, startup, and data-preservation proof, not physical gameplay or
+Internet-match acceptance. No production public-lobby endpoint is bundled, so
+Public Games remains unavailable on this build; Private Room can use the
+existing Dolphin traversal-backed room-code path. See
+[`build5-physical-ipad-install.md`](artifacts/2026-09-03/build5-physical-ipad-install.md)
+and [`PUBLIC-LOBBY-GOAL-LOOP.md`](PUBLIC-LOBBY-GOAL-LOOP.md).
+
 ## 2026-09-03 — Preview 1 release decision and accepted physical-iPad debt
 
 MeleePad v0.1.0 Preview 1 is the first completed developer-preview milestone.
@@ -18,8 +59,61 @@ remains performance debt rather than a release blocker. See
 
 Preview 1 is a source release. A playable iOS app still requires a locally
 generated GALE01 ARM64 module and a user-supplied supported disc image; neither
-belongs in the repository or release assets. Experimental multiplayer remains
-at the direct-connection preview boundary described below.
+belongs in the repository or release assets. The released Preview 1 remains at
+the direct-connection boundary; Preview 2 contains the Internet-room vertical
+slice described below.
+
+## 2026-09-03 — public lobby development slice reaches traversal join
+
+The Preview 2 native Online Play sheet has Public Games, Private Room, and
+Direct IP modes. Public cards expose host, region, occupancy, state,
+MeleePad version/build, GALE01 revision, and compatibility; Join remains
+disabled for mismatches. Host/Join, preset quick chat, Hide, and Report are
+wired to a new bounded standard-library lobby service. Public listings omit
+the traversal code and an exact-compatible authenticated Join is required to
+receive it.
+
+Ten service tests, focused source contracts, and a clean Simulator build
+pass. A live end-to-end development run published a fresh Dolphin traversal
+host through the local service; the iPad Simulator discovered it, authorized
+Join, and reached the native two-player compatible lobby at 54 ms. This proves
+the discovery-to-traversal path, not production availability.
+
+The first live quick-chat attempt exposed a guest-membership expiry after the
+20-second reservation. Authenticated guest heartbeats now renew presence every
+15 seconds; a repeated joined-lobby check delivered and rendered `Hello!`
+after the original expiry window.
+
+The reverse public-discovery direction also passes: the iPad Simulator hosted
+and published, a compatible Mac discovery session received the code only from
+Join, and the native host showed both peers compatible at 59 ms. Host Cancel
+removed the listing immediately.
+
+No lobby endpoint was deployed or bundled. HTTPS operations, durable
+moderation/report storage, monitoring, backups, abuse contact, physical-device
+and independent-network acceptance remain gates. See
+`docs/artifacts/2026-09-03/public-lobby-vertical-slice.md`.
+
+## 2026-09-03 — public Internet room vertical slice passes in both directions
+
+MeleePad-to-MeleePad Internet play is now possible in the retained engineering
+test. Dolphin's public traversal service is live, issued fresh eight-character
+codes, and connected Mac/iPad Simulator pairs with each endpoint hosting once.
+Both public-service sessions launched the synchronized game runtime and held
+roughly 4,700 rendered frames without canonical mismatch or disconnect. Direct
+cross-platform runs also crossed the old frame-120 failure in both directions.
+
+The old `timebase,ram` result was stale-build contamination: it disappeared
+after clean core/module/package rebuilds without tolerance, RAM exclusion, or
+timing changes. The new regional RAM and signed-timebase diagnostics remain.
+The native form now defaults to Internet Room, displays/accepts a room code,
+and keeps Direct IP available as an adjacent advanced path.
+
+This is not the friends-beta or release gate. Independent outside networks,
+physical devices, full matches/results/rematches, lifecycle failures, NAT
+success rate, security/privacy, and a supported service-operations decision
+remain open. See
+`docs/artifacts/2026-09-03/g9-public-internet-room-pass.md`.
 
 ## 2026-09-03 — reconciled netplay beta stop checkpoint
 

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -257,13 +257,14 @@ uncertainty. The iPhone/iPad app already links ENet/SFML and already publishes
 touch/controller state through the GameCube pipe that netplay polls. Dolphin's
 CC0 traversal server and eight-character room-code protocol are also present.
 
-The current iOS form is now labeled **Experimental Multiplayer** and explains
-its actual boundary: there are no MeleePad matchmaking servers or room codes,
-one player hosts a direct peer connection, and same-LAN or private-VPN testing
-is the practical starting point. Complete matches remain unreliable. Direct IP
-does not remove Internet NAT work; a broadly usable peer-to-peer flow still
-needs traversal and possibly relay infrastructure, plus the determinism gates
-below. Do not market the current form as finished online multiplayer.
+The unreleased iOS candidate now offers a real Internet Room path backed by
+Dolphin's live public traversal service, with Direct IP retained for advanced
+use. Both Mac/iPad Simulator host directions create/resolve codes and sustain
+synchronized execution. This proves feasibility, not a finished beta: public
+service support is not controlled by MeleePad, complete physical-device matches
+and real outside-network NAT behavior remain unmeasured, and strict NAT may
+still require relay or a narrower scope. Do not market the current form as
+finished online multiplayer.
 
 The first defect is now closed by canonical outer patches: the pre-fix
 GameCube assertion failed with exit `19`, while the candidate passes explicit

--- a/docs/artifacts/2026-09-03/build5-physical-ipad-install.md
+++ b/docs/artifacts/2026-09-03/build5-physical-ipad-install.md
@@ -1,0 +1,69 @@
+# Build 5 physical-iPad test installation
+
+Date: 2026-09-03
+Candidate: MeleePad `0.1.0` build `5`
+Source base: `514f758` plus the unreleased networking/public-lobby working tree
+Result: **PASS for signed install, launch, and data preservation; gameplay and
+Internet-match acceptance remain open**
+
+## Scope
+
+Put the latest working candidate on the connected iPad Pro without deleting
+the installed game's data or overstating what an automated launch proves.
+This was an in-place development deployment, not a public release or service
+deployment.
+
+## Build and verification
+
+- Replayed the dependency patches and rebuilt the iPhoneOS ModernGekko core;
+  the provisioned GALE01 native module remained current.
+- Built the Release target for iPhoneOS with the installed app's existing
+  bundle identifier, `com.ssbmpad.SsbmPad`.
+- Verified the product metadata reports marketing version `0.1.0` and bundle
+  version `5`.
+- `codesign --verify --deep --strict` passed. The signed executable SHA-256 is
+  `603ff764053fb00a2ac0d1114e5c501b6e0c67bd6a0a2305c53dfa694a2f9f13`.
+- The complete `scripts/check-repository.sh` gate passed, including ten public
+  lobby tests and all netplay contracts.
+
+## Data-preserving install
+
+The previous installation was `0.1.0` build `4` under
+`com.ssbmpad.SsbmPad`. Before changing it, GC saves, Dolphin configuration,
+and preferences were copied to
+`/tmp/meleepad-ipad-prebuild5-backup-20260903-2303`.
+
+Build 5 was installed directly over build 4. No uninstall, app-container
+deletion, or remove-existing-content operation was used.
+
+A post-install readback before first launch proved:
+
+- the GALE01 GCI save is byte-identical to the backup;
+- the complete configuration and preferences trees are byte-identical;
+- `GALE01.iso` remains present at 1,459,978,240 bytes; and
+- the extracted `GALE01` tree remains present with 1,214 files.
+
+The full pre-launch readback is retained temporarily at
+`/tmp/meleepad-ipad-postinstall5-prelaunch-4hdOz0Dc`.
+
+## Launch verification
+
+The installed-app inventory reports `com.ssbmpad.SsbmPad`, version `0.1.0`,
+build `5`. `devicectl` launched it successfully and the MeleePad executable
+appeared in the device process list. A second GCI readback after launch was
+byte-identical to the pre-install backup.
+
+## Claim boundary and next test
+
+This run proves that build 5 can be signed, installed, and started on the
+physical iPad while preserving the user's game data and save. It does not
+prove rendered gameplay, control/audio quality, lifecycle recovery, thermal
+behavior, or a completed physical-device Internet match.
+
+The build intentionally contains no production public-lobby endpoint. Public
+Games should therefore present the unavailable-service path. Private Room and
+Direct IP remain available, and Private Room uses the already proven Dolphin
+traversal room-code transport. The next retained acceptance run should pair
+this iPad with a second endpoint on an independent network, complete a
+five-minute match through results/rematch/leave, and capture the failure paths
+listed in `docs/PUBLIC-LOBBY-GOAL-LOOP.md`.

--- a/docs/artifacts/2026-09-03/g9-public-internet-room-pass.md
+++ b/docs/artifacts/2026-09-03/g9-public-internet-room-pass.md
@@ -1,0 +1,98 @@
+# G9 public Internet room vertical-slice pass
+
+Date: 2026-09-03
+Scope: unreleased Mac + iPad Simulator engineering candidate
+Result: Internet room-code play is possible; beta/release acceptance remains open
+
+## Research result
+
+The premise that no usable servers exist is false in the narrow transport
+sense. Dolphin mainline still defaults to `stun.dolphin-emu.org` on UDP 6262
+with alternate UDP 6226, and its public lobby endpoint returned active sessions
+during this run, including a GALE01 revision-2 room. Dolphin's traversal server
+issued and resolved fresh eight-character host codes for every retained
+MeleePad test.
+
+This does not make Slippi a drop-in service. Slippi provides active rollback
+matchmaking for its customized Dolphin client, while its matchmaking service
+source and protocol are not a public compatibility surface for MeleePad.
+
+Sources:
+
+- https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/Core/Config/NetplaySettings.cpp
+- https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/Core/NetPlayServer.cpp
+- https://slippi.gg/netplay
+- https://github.com/project-slippi/slippi-wiki/blob/master/GETTING_STARTED.md
+
+## Change
+
+- Add traversal-backed room hosting and joining to the platform-neutral
+  `NetplaySession`, using Dolphin's published default host and ports.
+- Keep the host's local client direct while the server owns the traversal
+  socket, matching Dolphin's upstream ownership model.
+- Surface the ephemeral room code in the session snapshot and Mac lobby.
+- Add `--netplay-room-host` and `--netplay-room-join` runner paths.
+- Make Internet Room the iOS setup default, retain Direct IP as the adjacent
+  advanced fallback, show the host code in the lobby, and validate join codes.
+- State the security boundary in-product: a room code is a locator, not a
+  password or end-to-end encryption.
+- Add Simulator-only automation for reproducible host/join/ready/start testing;
+  room-code logging remains disabled unless the private trace variable is set.
+
+The durable dependency change is
+`patches/moderngekko/0020-netplay-internet-rooms.patch` and is wired into the
+dependency bootstrap.
+
+## Retained runs
+
+No IP address or room code is retained in this artifact.
+
+1. Clean iPad-host/Mac-join direct connection sustained 4,769 iPad-rendered
+   frames at 59.9 FPS with no canonical mismatch or disconnect.
+2. Clean Mac-host/iPad-join direct connection sustained 3,588 iPad-rendered
+   frames at 59.9 FPS with no canonical mismatch or disconnect.
+3. Public-service Mac-host/iPad-join resolved a fresh code, launched both
+   synchronized runtimes, armed the canonical boundary on both peers, and
+   sustained 4,768 iPad-rendered frames. The last sample was 59.7 FPS/VPS and
+   1.009 speed with no mismatch or disconnect.
+4. Public-service iPad-host/Mac-join resolved a second fresh code, launched both
+   synchronized runtimes, and sustained 4,707 iPad-rendered frames. The last
+   sample was 59.1 FPS/VPS and 1.011 speed with no mismatch or disconnect.
+
+The earlier frame-120 `timebase,ram` failure did not reproduce after completely
+rebuilding the iOS core/module and Mac package from the current checkout. No
+timebase tolerance, RAM exclusion, timing adjustment, or gameplay semantic
+change was used. The prior failure is therefore classified as stale build
+contamination, not evidence that cross-platform deterministic play is broken.
+The new regional RAM and signed-timebase diagnostics remain in place so a real
+future mismatch fails closed with useful location data.
+
+## Verification
+
+- ModernGekko netplay protocol and session tests: pass.
+- Internet-room and native-lobby source contracts: pass.
+- New dependency patch reverse-check and patch parse: pass.
+- Rebuilt Simulator core/module/provisioned libraries: pass.
+- Release iPad Simulator link: pass.
+- Visual setup review: pass; Internet Room is primary, Direct IP remains
+  available, host fields fit without clipping, and the navigation title is
+  legible on the dark form sheet.
+
+## Claim boundary and next loop
+
+It is now accurate to say: **MeleePad-to-MeleePad Internet room play works in
+the retained public-traversal Simulator/Mac test.** It is not yet accurate to
+say the friends beta is ready. These remain open:
+
+- complete five-minute match, results, rematch, and clean leave/reconnect;
+- physical iPhone/iPad testing;
+- two genuinely independent outside networks and a NAT success matrix;
+- malformed/expired/full/game-running and service-outage recovery;
+- background, Wi-Fi-loss, host-loss, and controller-disconnect cleanup;
+- diagnostics redaction, security review, and release/package validation;
+- a support/availability decision for relying on Dolphin's public service or
+  operating a separately authorized MeleePad endpoint.
+
+Continue the goal loop at B1/B2 acceptance while treating B3/B4 as a proven
+vertical slice, not as a beta claim. Do not deploy infrastructure or publish a
+release without separate authority.

--- a/docs/artifacts/2026-09-03/preview2-public-package.md
+++ b/docs/artifacts/2026-09-03/preview2-public-package.md
@@ -1,0 +1,37 @@
+# Preview 2 public package audit
+
+Date: 2026-09-03
+Candidate: MeleePad `0.1.0` build `5`
+Artifact: `MeleePad-v0.1.0-preview.2-module-free-unsigned.ipa`
+Result: **PASS for a public module-free app shell; not a playable IPA**
+
+## Build
+
+The current iPhoneOS Release target was built for generic ARM64 iOS with code
+signing disabled in a fresh DerivedData directory. The public packager removed
+the local development configuration and rejected any app containing a GALE01
+module, game/save file, provisioning profile, signature, key material, or
+private host path.
+
+## Retained checks
+
+- packaging the same app twice produced byte-identical IPA files;
+- ZIP integrity passed;
+- bundle identifier: `com.meleepad.MeleePad`;
+- marketing version: `0.1.0`;
+- bundle version: `5`;
+- architecture: ARM64;
+- platform/minimum: iPhoneOS 16.0;
+- code-signing inspection: unsigned;
+- no `gGALE01_recomp.dylib`, ISO/GCM/RVZ, GCI/save, mobileprovision,
+  certificate/key, development config, or private host path is present; and
+- SHA-256:
+  `797a4d9c218650bd6f7377f07d798d5f06ff46abcfee33c8cdbe44248a552519`.
+
+## Claim boundary
+
+This artifact is safe from the project-specific game-data and signing leaks
+checked above. It is not playable as downloaded because static recompilation
+happens on the build Mac and the generated game module is deliberately absent.
+The playable build remains local-only and requires the exact supported
+user-supplied GALE01 revision-0 disc image.

--- a/docs/artifacts/2026-09-03/public-lobby-vertical-slice.md
+++ b/docs/artifacts/2026-09-03/public-lobby-vertical-slice.md
@@ -1,0 +1,50 @@
+# Public lobby development vertical slice
+
+Date: 2026-09-03
+Result: pass for local service discovery and authorized traversal join
+Release result: not deployed; no public-lobby release claim
+
+## Change
+
+- Add a small standard-library lobby service for room discovery, exact
+  version/build/protocol/game compatibility, authenticated join, expiry,
+  preset quick chat, hide, report, and health checks.
+- Add an ephemeral native client that accepts HTTPS in products and permits
+  plaintext loopback only in Simulator development.
+- Replace the two-way Internet Room/Direct IP selector with Public Games,
+  Private Room, and Direct IP while preserving both existing connection paths.
+- Add version-aware room cards, explicit compatibility badges, Host/Join,
+  bounded quick chat, and a Safety menu.
+
+## Retained proof
+
+- Ten service tests pass, including secret room-code handling, room expiry,
+  full-room/non-member refusal, incompatibility refusal, host-only actions,
+  free-text rejection, quick-chat
+  rate limiting, authentication/input rejection, and report-to-hide behavior.
+- The iPad Simulator build succeeds and the public-room browser renders one
+  compatible room without clipping or hierarchy regressions.
+- The iPad Simulator discovered a room backed by a fresh Dolphin traversal
+  host, authorized Join, and reached the native two-player lobby. The host and
+  guest showed matching compatibility and a measured 54 ms guest ping.
+- A live UI check found and fixed the initial guest reservation expiring under
+  an active traversal session. Authenticated guest heartbeats now extend
+  presence; after the original 20-second window, preset quick chat delivered
+  and rendered in the connected lobby.
+- The direction was then reversed: the iPad Simulator used **Host Public
+  Game**, an authenticated compatible client discovered the listing without a
+  code, and a Mac joined the disclosed traversal code. The native host showed
+  both compatible players at 59 ms. Cancel removed the room immediately; a
+  fresh listing returned zero rooms.
+- No ephemeral room code, bearer token, IP address, game data, or save data is
+  retained in this artifact.
+
+## Boundary
+
+The service runs locally and in memory. It is not a production deployment and
+does not yet provide durable moderation, a published abuse contact, monitoring,
+backups, or a public availability commitment. Physical-device and independent-
+network acceptance also remain open.
+
+See `docs/PUBLIC-LOBBY-DESIGN.md` and
+`docs/PUBLIC-LOBBY-GOAL-LOOP.md` for the design and remaining release gates.

--- a/patches/moderngekko-dolphin/0044-netplay-canonical-boundary.patch
+++ b/patches/moderngekko-dolphin/0044-netplay-canonical-boundary.patch
@@ -23,7 +23,7 @@ diff --git a/Source/Core/Core/NetPlay/NetPlayClient.cpp b/Source/Core/Core/NetPl
  
      sf::Packet packet;
      packet << MessageID::TimeBase;
-@@ -1789,6 +1797,14 @@ void NetPlayClient::SendTimeBase()
+@@ -1789,6 +1797,16 @@ void NetPlayClient::SendTimeBase()
      packet << native_dispatches;
      packet << charged_cycles;
      packet << bursts;
@@ -35,6 +35,8 @@ diff --git a/Source/Core/Core/NetPlay/NetPlayClient.cpp b/Source/Core/Core/NetPl
 +    packet << canonical.fpr_state_hash;
 +    packet << canonical.paired_state_hash;
 +    packet << canonical.ram_hash;
++    for (const u64 region_hash : canonical.ram_region_hashes)
++      packet << region_hash;
  
      netplay_client->SendAsync(std::move(packet));
    }
@@ -52,10 +54,22 @@ diff --git a/Source/Core/Core/NetPlay/NetPlayClient.h b/Source/Core/Core/NetPlay
 diff --git a/Source/Core/Core/NetPlay/NetPlayCommon.h b/Source/Core/Core/NetPlay/NetPlayCommon.h
 --- a/Source/Core/Core/NetPlay/NetPlayCommon.h
 +++ b/Source/Core/Core/NetPlay/NetPlayCommon.h
-@@ -20,6 +20,31 @@ using namespace std::chrono_literals;
+@@ -1,7 +1,8 @@
+ // Copyright 2021 Dolphin Emulator Project
+ // SPDX-License-Identifier: GPL-2.0-or-later
+ 
+ #pragma once
+ 
++#include <array>
+ #include <SFML/Network/Packet.hpp>
+ 
+@@ -20,6 +21,46 @@ using namespace std::chrono_literals;
  // connection is disconnected
  constexpr std::chrono::milliseconds PEER_TIMEOUT = 30s;
  
++constexpr u32 CANONICAL_RAM_REGION_SIZE = 1024 * 1024;
++constexpr size_t CANONICAL_RAM_REGION_COUNT = 32;
++
 +// Architectural state captured at the configured guest idle PC. Unlike the
 +// ordinary TimeBase packet fields, every value here comes from one explicit
 +// emulated boundary and can therefore be compared across host architectures.
@@ -69,6 +83,7 @@ diff --git a/Source/Core/Core/NetPlay/NetPlayCommon.h b/Source/Core/Core/NetPlay
 +  u64 fpr_state_hash = 0;
 +  u64 paired_state_hash = 0;
 +  u64 ram_hash = 0;
++  std::array<u64, CANONICAL_RAM_REGION_COUNT> ram_region_hashes{};
 +};
 +
 +inline bool CanonicalStateMatches(const CanonicalStateSnapshot& lhs,
@@ -78,7 +93,19 @@ diff --git a/Source/Core/Core/NetPlay/NetPlayCommon.h b/Source/Core/Core/NetPlay
 +         lhs.timebase == rhs.timebase && lhs.state_hash == rhs.state_hash &&
 +         lhs.integer_state_hash == rhs.integer_state_hash &&
 +         lhs.fpr_state_hash == rhs.fpr_state_hash &&
-+         lhs.paired_state_hash == rhs.paired_state_hash && lhs.ram_hash == rhs.ram_hash;
++         lhs.paired_state_hash == rhs.paired_state_hash && lhs.ram_hash == rhs.ram_hash &&
++         lhs.ram_region_hashes == rhs.ram_region_hashes;
++}
++
++inline size_t CanonicalRamFirstDifferingRegion(const CanonicalStateSnapshot& lhs,
++                                               const CanonicalStateSnapshot& rhs)
++{
++  for (size_t i = 0; i < CANONICAL_RAM_REGION_COUNT; ++i)
++  {
++    if (lhs.ram_region_hashes[i] != rhs.ram_region_hashes[i])
++      return i;
++  }
++  return CANONICAL_RAM_REGION_COUNT;
 +}
 +
  bool CompressFileIntoPacket(const std::string& file_path, sf::Packet& packet);
@@ -92,7 +119,7 @@ diff --git a/Source/Core/Core/NetPlay/NetPlayProto.h b/Source/Core/Core/NetPlay/
  namespace NetPlay
  {
 -inline constexpr char MODERNGEKKO_NETPLAY_VERSION_SUFFIX[] = "|moderngekko-netplay-6";
-+inline constexpr char MODERNGEKKO_NETPLAY_VERSION_SUFFIX[] = "|moderngekko-netplay-7";
++inline constexpr char MODERNGEKKO_NETPLAY_VERSION_SUFFIX[] = "|moderngekko-netplay-8";
  inline constexpr u32 MODERNGEKKO_START_GAME_SENTINEL = 0x4d475336;
  
  enum class ControllerFamily
@@ -130,6 +157,8 @@ diff --git a/Source/Core/Core/NetPlay/NetPlayServer.cpp b/Source/Core/Core/NetPl
 +    canonical.fpr_state_hash = Common::PacketReadU64(packet);
 +    canonical.paired_state_hash = Common::PacketReadU64(packet);
 +    canonical.ram_hash = Common::PacketReadU64(packet);
++    for (u64& region_hash : canonical.ram_region_hashes)
++      region_hash = Common::PacketReadU64(packet);
 +
 +    if (m_desync_detected || canonical.sequence == 0)
        break;
@@ -282,7 +311,15 @@ diff --git a/Source/Core/Core/NetPlay/NetPlayServer.h b/Source/Core/Core/NetPlay
 diff --git a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h b/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h
 --- a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h
 +++ b/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h
-@@ -66,6 +66,22 @@ public:
+@@ -3,6 +3,7 @@
+ 
+ #pragma once
+ 
++#include <array>
+ #include <string>
+ #include <unordered_map>
+ #include <unordered_set>
+@@ -66,6 +67,23 @@ public:
    u64 GetDiagnosticChargedCycles() const { return m_charged_cycles; }
    u64 GetDiagnosticBursts() const { return m_bursts; }
  
@@ -296,6 +333,7 @@ diff --git a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h b/Source/C
 +    u64 fpr_state_hash = 0;
 +    u64 paired_state_hash = 0;
 +    u64 ram_hash = 0;
++    std::array<u64, 32> ram_region_hashes{};
 +  };
 +  NetplayBoundarySnapshot GetNetplayBoundarySnapshot() const
 +  {
@@ -305,12 +343,13 @@ diff --git a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h b/Source/C
    void ClearCache() override;
    void Jit(u32 em_address) override {}
    bool HandleFault(uintptr_t access_address, SContext* ctx) override { return false; }
-@@ -107,6 +123,8 @@ private:
+@@ -107,6 +125,9 @@ private:
  
    void LoadModule();
    void UpdateProfileCapture();
 +  void CaptureNetplayBoundarySnapshot();
 +  u64 HashSelectedRamPages() const;
++  std::array<u64, 32> HashSelectedRamRegions() const;
    void FlushDispatchFrameSamples(bool final);
    void FlushDispatchBurstSamples(bool final);
  
@@ -356,7 +395,7 @@ diff --git a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore_Sync.cpp b/S
  #include <cstring>
  
  namespace
-@@ -70,6 +71,46 @@ u64 StaticRecompCore::GetDiagnosticStateHash() const
+@@ -70,6 +71,65 @@ u64 StaticRecompCore::GetDiagnosticStateHash() const
    return FnvAppend(hash, parts, sizeof(parts));
  }
  
@@ -377,6 +416,25 @@ diff --git a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore_Sync.cpp b/S
 +  return hash;
 +}
 +
++std::array<u64, 32> StaticRecompCore::HashSelectedRamRegions() const
++{
++  constexpr u32 REGION_SIZE = 1024 * 1024;
++  constexpr u32 PAGE_SIZE = 4096;
++  constexpr u32 SAMPLE_SIZE = 64;
++  std::array<u64, 32> hashes;
++  hashes.fill(FNV_OFFSET);
++  for (u32 offset = 0; offset < m_guest.ram_size; offset += PAGE_SIZE)
++  {
++    const size_t region = offset / REGION_SIZE;
++    if (region >= hashes.size())
++      break;
++    const u32 remaining = m_guest.ram_size - offset;
++    const u32 size = remaining < SAMPLE_SIZE ? remaining : SAMPLE_SIZE;
++    hashes[region] = FnvAppend(hashes[region], m_guest.ram + offset, size);
++  }
++  return hashes;
++}
++
 +void StaticRecompCore::CaptureNetplayBoundarySnapshot()
 +{
 +  ++m_netplay_boundary_sequence;
@@ -392,6 +450,7 @@ diff --git a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore_Sync.cpp b/S
 +      .fpr_state_hash = GetDiagnosticFprStateHash(),
 +      .paired_state_hash = GetDiagnosticPairedStateHash(),
 +      .ram_hash = HashSelectedRamPages(),
++      .ram_region_hashes = HashSelectedRamRegions(),
 +  };
 +  if (m_netplay_boundary_sequence == 60)
 +  {

--- a/patches/moderngekko-dolphin/0045-netplay-canonical-difference-summary.patch
+++ b/patches/moderngekko-dolphin/0045-netplay-canonical-difference-summary.patch
@@ -23,9 +23,31 @@ diff --git a/Source/Core/Core/NetPlay/NetPlayServer.cpp b/Source/Core/Core/NetPl
 +        add_difference("fpr", canonical.fpr_state_hash != reference.fpr_state_hash);
 +        add_difference("paired", canonical.paired_state_hash != reference.paired_state_hash);
 +        add_difference("ram", canonical.ram_hash != reference.ram_hash);
++        const s64 timebase_delta = canonical.timebase >= reference.timebase ?
++                                       static_cast<s64>(canonical.timebase - reference.timebase) :
++                                       -static_cast<s64>(reference.timebase - canonical.timebase);
++        const size_t first_ram_region = CanonicalRamFirstDifferingRegion(reference, canonical);
 +        std::string mismatch = "netplay-canonical sequence=" +
 +                               std::to_string(canonical.sequence) +
-+                               " differences=" + differences;
++                               " differences=" + differences +
++                               " timebase_delta=" + std::to_string(timebase_delta);
++        if (first_ram_region != CANONICAL_RAM_REGION_COUNT)
++        {
++          mismatch += " ram_first_region=" + std::to_string(first_ram_region) +
++                      " ram_first_address=" +
++                      fmt::format("{:#010x}", 0x80000000u +
++                                                   first_ram_region * CANONICAL_RAM_REGION_SIZE);
++        }
          for (const TimeBaseRecord& record : timebases)
          {
-           mismatch += " pid=" + std::to_string(record.pid) +
+            mismatch += " pid=" + std::to_string(record.pid) +
+@@ -1192,7 +1220,14 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
+                       " canonical_ram_hash=" +
+-                          fmt::format("{:#018x}", record.canonical.ram_hash);
++                          fmt::format("{:#018x}", record.canonical.ram_hash);
++          if (first_ram_region != CANONICAL_RAM_REGION_COUNT)
++          {
++            mismatch += " canonical_ram_region_hash=" +
++                        fmt::format("{:#018x}",
++                                    record.canonical.ram_region_hashes[first_ram_region]);
++          }

--- a/patches/moderngekko/0018-netplay-canonical-boundary-test.patch
+++ b/patches/moderngekko/0018-netplay-canonical-boundary-test.patch
@@ -23,6 +23,7 @@ diff --git a/tests/netplay_protocol_test.cpp b/tests/netplay_protocol_test.cpp
 +      .paired_state_hash = 4,
 +      .ram_hash = 5,
 +  };
++  canonical.ram_region_hashes.fill(6);
 +  if (!NetPlay::CanonicalStateMatches(canonical, canonical))
 +    return 20;
 +  auto changed = canonical;
@@ -45,6 +46,15 @@ diff --git a/tests/netplay_protocol_test.cpp b/tests/netplay_protocol_test.cpp
 +  changed.ram_hash ^= 1;
 +  if (NetPlay::CanonicalStateMatches(canonical, changed))
 +    return 25;
++  changed = canonical;
++  changed.ram_region_hashes[3] ^= 1;
++  if (NetPlay::CanonicalStateMatches(canonical, changed))
++    return 26;
++  if (NetPlay::CanonicalRamFirstDifferingRegion(canonical, changed) != 3)
++    return 27;
++  if (NetPlay::CanonicalRamFirstDifferingRegion(canonical, canonical) !=
++      NetPlay::CANONICAL_RAM_REGION_COUNT)
++    return 28;
 +
    moderngekko::GameMetadata metadata;
    metadata.disc_id = "TEST01";

--- a/patches/moderngekko/0020-netplay-internet-rooms.patch
+++ b/patches/moderngekko/0020-netplay-internet-rooms.patch
@@ -1,0 +1,210 @@
+diff --git a/tools/moderngekko_run.cpp b/tools/moderngekko_run.cpp
+--- a/tools/moderngekko_run.cpp
++++ b/tools/moderngekko_run.cpp
+@@ -37,7 +37,8 @@
+                "       [--graphics <backend>] [--audio <backend>]\n"
+                "       [--mods <directory>] [--no-mods]\n"
+                "       [--wayland] [-X11] [--headless] [--allow-interpreter]\n"
+-               "       [--netplay-host | --netplay-join <host>] "
++               "       [--netplay-host | --netplay-join <host> |\n"
++               "        --netplay-room-host | --netplay-room-join <code>] "
+                "[--netplay-port <port>]\n"
+                "       [--nickname <name>] [--buffer <auto|1-20>] "
+                "[--controller <device>]...\n"
+@@ -132,6 +133,7 @@
+   std::filesystem::path module_path;
+   bool use_default_mods = true;
+   std::optional<moderngekko::frontend::NetplayRole> netplay_role;
++  bool netplay_use_traversal = false;
+   std::string netplay_address;
+   std::optional<std::uint16_t> netplay_port;
+   std::string netplay_nickname;
+@@ -175,6 +177,13 @@
+     else if (arg == "--netplay-join") {
+       netplay_role = moderngekko::frontend::NetplayRole::Join;
+       netplay_address = value("--netplay-join");
++    } else if (arg == "--netplay-room-host") {
++      netplay_role = moderngekko::frontend::NetplayRole::Host;
++      netplay_use_traversal = true;
++    } else if (arg == "--netplay-room-join") {
++      netplay_role = moderngekko::frontend::NetplayRole::Join;
++      netplay_use_traversal = true;
++      netplay_address = value("--netplay-room-join");
+     } else if (arg == "--netplay-port") {
+       const std::string port_value = value("--netplay-port");
+       unsigned int port = 0;
+@@ -317,6 +326,7 @@
+   if (netplay_role) {
+     moderngekko::frontend::NetplayOptions options;
+     options.role = *netplay_role;
++    options.use_traversal = netplay_use_traversal;
+     options.address = netplay_address.empty() ? frontend_config.netplay_address
+                                               : netplay_address;
+     options.port = netplay_port.value_or(frontend_config.netplay_port);
+diff --git a/tools/netplay_session.cpp b/tools/netplay_session.cpp
+--- a/tools/netplay_session.cpp
++++ b/tools/netplay_session.cpp
+@@ -149,6 +149,9 @@
+   std::vector<ControllerOption> available = EnumerateControllers();
+   const bool auto_ready = EnvironmentEnabled("MELEEPAD_NETPLAY_AUTO_READY");
+   const bool auto_start = EnvironmentEnabled("MELEEPAD_NETPLAY_AUTO_START");
++  const bool trace_room_code =
++      EnvironmentEnabled("MELEEPAD_NETPLAY_TRACE_ROOM_CODE");
++  bool room_code_reported = false;
+   auto last_refresh = std::chrono::steady_clock::now();
+   bool running = true;
+   while (running) {
+@@ -162,6 +165,10 @@
+     }
+ 
+     const NetplayLobbySnapshot snapshot = session.Snapshot();
++    if (trace_room_code && !room_code_reported && !snapshot.room_code.empty()) {
++      std::cerr << "netplay: room code: " << snapshot.room_code << '\n';
++      room_code_reported = true;
++    }
+     const std::vector<NetplayPlayerSnapshot> &players = snapshot.players;
+     const u8 assigned = snapshot.assigned_controllers;
+     if (assigned > 0 && options.controllers.size() > assigned) {
+@@ -186,14 +193,26 @@
+                  ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove |
+                      ImGuiWindowFlags_NoSavedSettings);
+     const bool hosting = options.role == NetplayRole::Host;
+-    ImGui::TextUnformatted(hosting ? "Hosting direct-IP netplay"
+-                                   : "Connected to direct-IP host");
++    ImGui::TextUnformatted(options.use_traversal
++                               ? (hosting ? "Hosting Internet room"
++                                          : "Connected to Internet room")
++                               : (hosting ? "Hosting direct-IP netplay"
++                                          : "Connected to direct-IP host"));
+     if (hosting) {
+-      ImGui::Text("UDP port: %u", snapshot.port);
+-      for (const auto &[interface_name, address] : snapshot.interfaces)
+-        ImGui::Text("%s: %s", interface_name.c_str(), address.c_str());
++      if (options.use_traversal)
++        ImGui::Text("Room code: %s", snapshot.room_code.empty()
++                                         ? "Connecting..."
++                                         : snapshot.room_code.c_str());
++      else {
++        ImGui::Text("UDP port: %u", snapshot.port);
++        for (const auto &[interface_name, address] : snapshot.interfaces)
++          ImGui::Text("%s: %s", interface_name.c_str(), address.c_str());
++      }
+     } else {
+-      ImGui::Text("Host: %s:%u", options.address.c_str(), options.port);
++      if (options.use_traversal)
++        ImGui::Text("Room code: %s", options.address.c_str());
++      else
++        ImGui::Text("Host: %s:%u", options.address.c_str(), options.port);
+     }
+     ImGui::Text("Input buffer: %u frames%s", snapshot.buffer_frames,
+                 hosting && snapshot.adaptive_buffer ? " (auto)" : "");
+diff --git a/tools/netplay_session.hpp b/tools/netplay_session.hpp
+--- a/tools/netplay_session.hpp
++++ b/tools/netplay_session.hpp
+@@ -31,6 +31,7 @@
+ 
+ struct NetplayOptions {
+   NetplayRole role = NetplayRole::Join;
++  bool use_traversal = false;
+   std::string address = "127.0.0.1";
+   std::uint16_t port = 2626;
+   std::string nickname = "Player";
+@@ -62,6 +63,7 @@
+   NetplayState state = NetplayState::Idle;
+   NetplayRole role = NetplayRole::Join;
+   std::uint16_t port = 0;
++  std::string room_code;
+   std::vector<std::pair<std::string, std::string>> interfaces;
+   std::vector<NetplayPlayerSnapshot> players;
+   std::uint8_t assigned_controllers = 0;
+diff --git a/tools/netplay_session_core.cpp b/tools/netplay_session_core.cpp
+--- a/tools/netplay_session_core.cpp
++++ b/tools/netplay_session_core.cpp
+@@ -2,6 +2,7 @@
+ 
+ #include "netplay_compatibility.hpp"
+ 
++#include "Common/TraversalClient.h"
+ #include "Core/Boot/Boot.h"
+ #include "Core/IOS/FS/FileSystem.h"
+ #include "Core/NetPlay/NetPlayClient.h"
+@@ -18,6 +19,10 @@
+ namespace moderngekko::frontend {
+ namespace {
+ 
++constexpr std::string_view TRAVERSAL_HOST = "stun.dolphin-emu.org";
++constexpr u16 TRAVERSAL_PORT = 6262;
++constexpr u16 TRAVERSAL_PORT_ALT = 6226;
++
+ class SessionUI final : public NetPlay::NetPlayUI {
+ public:
+   explicit SessionUI(std::shared_ptr<UICommon::GameFile> game)
+@@ -123,9 +128,22 @@
+     m_error = message;
+   }
+   void OnTraversalError(Common::TraversalClient::FailureReason) override {
+-    OnConnectionError("Direct connection failed");
++    OnConnectionError("Internet room connection failed");
+   }
+-  void OnTraversalStateChanged(Common::TraversalClient::State) override {}
++  void OnTraversalStateChanged(Common::TraversalClient::State state) override {
++    std::lock_guard lock(m_mutex);
++    switch (state) {
++    case Common::TraversalClient::State::Connecting:
++      m_status = "Connecting to the Internet room service";
++      break;
++    case Common::TraversalClient::State::Connected:
++      m_status = "Internet room is ready";
++      break;
++    case Common::TraversalClient::State::Failure:
++      m_status = "Internet room service is unavailable";
++      break;
++    }
++  }
+   void OnGameStartAborted() override {
+     std::lock_guard lock(m_mutex);
+     m_error = "Game start was aborted";
+@@ -257,10 +275,13 @@
+       CompatibilityFingerprint(impl->runtime_config, *inspected.metadata));
+   impl->ui = std::make_unique<SessionUI>(impl->game);
+   const NetPlay::NetTraversalConfig direct{};
++  const NetPlay::NetTraversalConfig traversal{
++      impl->options.use_traversal, std::string(TRAVERSAL_HOST), TRAVERSAL_PORT,
++      TRAVERSAL_PORT_ALT};
+   if (impl->options.role == NetplayRole::Host) {
+     impl->ui->SetHosting(true);
+     impl->server = std::make_unique<NetPlay::NetPlayServer>(
+-        impl->options.port, false, impl->ui.get(), direct);
++        impl->options.port, false, impl->ui.get(), traversal);
+     if (!impl->server->is_connected)
+       return {};
+     impl->server->SetControllerFamily(NetPlay::ControllerFamily::GameCube);
+@@ -278,7 +299,7 @@
+   } else {
+     impl->client = std::make_unique<NetPlay::NetPlayClient>(
+         impl->options.address, impl->options.port, impl->ui.get(),
+-        impl->options.nickname, direct,
++        impl->options.nickname, traversal,
+         static_cast<u8>(impl->options.controllers.size()));
+   }
+ 
+@@ -325,8 +346,17 @@
+   if (m_impl->server) {
+     snapshot.port = m_impl->server->GetPort();
+     snapshot.can_start = m_impl->server->CanStart();
+-    for (const std::string &name : m_impl->server->GetInterfaceSet())
+-      snapshot.interfaces.emplace_back(name, m_impl->server->GetInterfaceHost(name));
++    if (m_impl->options.use_traversal) {
++      if (Common::g_TraversalClient && Common::g_TraversalClient->IsConnected()) {
++        const Common::TraversalHostId host_id =
++            Common::g_TraversalClient->GetHostID();
++        if (host_id[0] != '\0')
++          snapshot.room_code.assign(host_id.begin(), host_id.end());
++      }
++    } else {
++      for (const std::string &name : m_impl->server->GetInterfaceSet())
++        snapshot.interfaces.emplace_back(name, m_impl->server->GetInterfaceHost(name));
++    }
+   } else {
+     snapshot.port = m_impl->options.port;
+   }

--- a/scripts/bootstrap-dependencies.sh
+++ b/scripts/bootstrap-dependencies.sh
@@ -150,6 +150,7 @@ netplay_timebase_status_patch="$ROOT/patches/moderngekko/0016-netplay-timebase-s
 executable_boot_caller_idle_patch="$ROOT/patches/moderngekko/0017-executable-boot-caller-idle-config.patch"
 netplay_canonical_boundary_test_patch="$ROOT/patches/moderngekko/0018-netplay-canonical-boundary-test.patch"
 netplay_canonical_status_patch="$ROOT/patches/moderngekko/0019-netplay-canonical-status-history.patch"
+netplay_internet_rooms_patch="$ROOT/patches/moderngekko/0020-netplay-internet-rooms.patch"
 render_log_patch="$ROOT/patches/moderngekko-dolphin/0002-buffer-render-time-logging.patch"
 idle_patch="$ROOT/patches/moderngekko-dolphin/0003-gale01r0-staticrecomp-idle.patch"
 memory_watcher_patch="$ROOT/patches/moderngekko-dolphin/0004-static-recomp-memory-watcher.patch"
@@ -344,6 +345,9 @@ apply_patch_once_or_marker "$MG" "$netplay_canonical_boundary_test_patch" \
 apply_patch_once_or_marker "$MG" "$netplay_canonical_status_patch" \
   tools/netplay_session_core.cpp \
   'message.starts_with("netplay-canonical")'
+apply_patch_once_or_marker "$MG" "$netplay_internet_rooms_patch" \
+  tools/netplay_session_core.cpp \
+  'stun.dolphin-emu.org'
 verify_patch_scope "$MG" "$mg_patch" "$ROOT"/patches/moderngekko/*.patch -- \
   vendor/dolphin
 verify_patch_scope "$MG/vendor/dolphin" "$dolphin_patch" "$mg_patch" \

--- a/scripts/check-repository.sh
+++ b/scripts/check-repository.sh
@@ -35,8 +35,10 @@ tests/test-game-data-setup.sh
 tests/test-ios-audio-diagnostics.sh
 tests/test-ios-external-pipe-input.sh
 tests/test-ios-online-play-lobby.sh
+tests/test-public-lobby.sh
 tests/test-netplay-timebase-telemetry.sh
 tests/test-netplay-canonical-boundary.sh
+tests/test-netplay-internet-rooms.sh
 tests/test-cross-platform-idle-policy.sh
 tests/test-static-recomp-loop-hoists.sh
 tests/test-frame-workload-attribution.sh

--- a/scripts/package-public-ios-ipa.sh
+++ b/scripts/package-public-ios-ipa.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Package a reproducible, unsigned, game-data-free iOS app shell.
+# A playable local build requires the user-generated GALE01 module and must not
+# be published through this script.
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+SOURCE_APP=${1:-}
+OUTPUT=${2:-"$ROOT/artifacts/MeleePad-v0.1.0-preview.2-module-free-unsigned.ipa"}
+
+if [[ -z "$SOURCE_APP" || ! -d "$SOURCE_APP" ]]; then
+  echo "usage: $0 /path/to/MeleePad.app [output.ipa]" >&2
+  exit 2
+fi
+
+SOURCE_APP="$(cd "$(dirname "$SOURCE_APP")" && pwd)/$(basename "$SOURCE_APP")"
+OUTPUT_DIR="$(dirname "$OUTPUT")"
+mkdir -p "$OUTPUT_DIR"
+OUTPUT="$(cd "$OUTPUT_DIR" && pwd)/$(basename "$OUTPUT")"
+
+source_prohibited="$(find "$SOURCE_APP" -type f \( \
+    -name 'gGALE01_recomp.dylib' -o -name '*.iso' -o -name '*.gcm' -o \
+    -name '*.rvz' -o -name '*.gci' -o -name '*.sav' -o \
+    -name 'embedded.mobileprovision' \) -print -quit)"
+if [[ -n "$source_prohibited" ]]; then
+  echo "refusing to package an app containing a game module, game/save data, or provisioning profile" >&2
+  exit 1
+fi
+
+STAGING="$(mktemp -d "${TMPDIR:-/tmp}/meleepad-public-ipa.XXXXXX")"
+trap 'rm -rf "$STAGING"' EXIT
+mkdir -p "$STAGING/Payload"
+ditto "$SOURCE_APP" "$STAGING/Payload/MeleePad.app"
+APP="$STAGING/Payload/MeleePad.app"
+
+# Development manifests can contain local absolute paths even when the files
+# they name are not bundled. They have no purpose in the public shell.
+rm -f "$APP/dev-config.plist" "$APP/embedded.mobileprovision"
+rm -rf "$APP/_CodeSignature"
+
+identifier="$(plutil -extract CFBundleIdentifier raw -o - "$APP/Info.plist")"
+version="$(plutil -extract CFBundleShortVersionString raw -o - "$APP/Info.plist")"
+build="$(plutil -extract CFBundleVersion raw -o - "$APP/Info.plist")"
+executable="$(plutil -extract CFBundleExecutable raw -o - "$APP/Info.plist")"
+
+[[ "$identifier" == com.meleepad.MeleePad ]]
+[[ "$version" == 0.1.0 ]]
+[[ "$build" == 5 ]]
+[[ "$(lipo -archs "$APP/$executable")" == arm64 ]]
+
+if codesign -d "$APP" >/dev/null 2>&1; then
+  echo "refusing to package a signed app" >&2
+  exit 1
+fi
+packaged_prohibited="$(find "$APP" -type f \( \
+    -name 'gGALE01_recomp.dylib' -o -name '*.iso' -o -name '*.gcm' -o \
+    -name '*.rvz' -o -name '*.gci' -o -name '*.sav' -o \
+    -name '*.mobileprovision' -o -name '*.p12' -o -name '*.cer' -o \
+    -name '*.key' \) -print -quit)"
+if [[ -n "$packaged_prohibited" ]]; then
+  echo "public package audit found prohibited private or game-derived data" >&2
+  exit 1
+fi
+private_paths="$(find "$APP" -type f -exec strings -a {} + | \
+  rg '/Users/|/tmp/meleepad' || true)"
+if [[ -n "$private_paths" ]]; then
+  echo "public package audit found a private host path" >&2
+  exit 1
+fi
+
+find "$STAGING/Payload" -exec touch -h -t 202601010000 {} +
+TEMP_IPA="$STAGING/MeleePad.ipa"
+(cd "$STAGING" && TZ=UTC zip -X -q -y -r "$TEMP_IPA" Payload)
+unzip -tq "$TEMP_IPA" >/dev/null
+mv "$TEMP_IPA" "$OUTPUT"
+checksum="$(shasum -a 256 "$OUTPUT" | awk '{print $1}')"
+printf '%s  %s\n' "$checksum" "$(basename "$OUTPUT")" > "$OUTPUT.sha256"
+
+echo "Public module-free IPA: $OUTPUT"
+echo "SHA-256: $checksum"
+echo "This app shell is not playable until a private generated module is added and the bundle is signed."

--- a/services/lobby/README.md
+++ b/services/lobby/README.md
@@ -1,0 +1,49 @@
+# MeleePad lobby service
+
+This small service discovers compatible MeleePad traversal rooms. It does not
+relay or inspect gameplay traffic.
+
+Local development:
+
+```sh
+python3 -m services.lobby.server --host 127.0.0.1 --port 8765
+```
+
+Run tests from the repository root:
+
+```sh
+python3 -m unittest services.lobby.test_server
+```
+
+The iOS Simulator can use the service by launching MeleePad with
+`MELEEPAD_LOBBY_BASE_URL=http://127.0.0.1:8765`. Plain HTTP is accepted only
+for a loopback Simulator endpoint. Any deployed endpoint must use HTTPS.
+
+To keep one synthetic room visible while refining the UI, run this in a
+second terminal. Its placeholder traversal code is never returned by a list
+request and is not suitable for a gameplay test:
+
+```sh
+python3 -m services.lobby.demo_host
+```
+
+Security properties of this vertical slice:
+
+- opaque two-hour bearer sessions, stored server-side only as SHA-256 hashes;
+- exact app build, protocol, game, and revision compatibility checks;
+- traversal codes omitted from public room listings and returned only by Join;
+- 45-second host/member heartbeat expiry and 20-second initial join
+  reservations;
+- allow-listed request fields, 8 KiB body limit, bounded room/message storage,
+  and per-source/per-session rate limits;
+- preset quick-chat only—no arbitrary public text;
+- server-side display-name filtering plus report and block actions;
+- no standard request logs, IPs, tokens, traversal codes, or message contents in
+  application diagnostics;
+- no browser CORS surface.
+
+Before deployment, place the service behind TLS, connection limits, a trusted
+reverse proxy/WAF, persistent moderation/report storage, operational metrics,
+restart supervision, backups, and an abuse-response process with published
+contact information. The in-memory single-process store is intentionally a
+development vertical slice, not production infrastructure.

--- a/services/lobby/__init__.py
+++ b/services/lobby/__init__.py
@@ -1,0 +1,1 @@
+"""MeleePad public-lobby service."""

--- a/services/lobby/demo_host.py
+++ b/services/lobby/demo_host.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Publish one safe, synthetic room card for local UI development."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import urllib.request
+
+
+def request(base: str, path: str, payload: dict, token: str | None = None) -> dict:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    operation = urllib.request.Request(
+        base + path,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST" if path != "/heartbeat" else "PUT",
+    )
+    with urllib.request.urlopen(operation, timeout=3) as response:
+        return json.load(response)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Publish a local demo lobby room")
+    parser.add_argument("--base", default="http://127.0.0.1:8765")
+    parser.add_argument("--name", default="FalconFan")
+    parser.add_argument("--code", default="00000000")
+    args = parser.parse_args()
+    session = request(
+        args.base,
+        "/v1/sessions",
+        {
+            "display_name": args.name,
+            "app_version": "0.1.0",
+            "build": "4",
+            "protocol": "moderngekko-netplay-8",
+            "game_id": "GALE01",
+            "game_revision": "r0",
+        },
+    )
+    room = request(
+        args.base,
+        "/v1/rooms",
+        {"traversal_code": args.code, "region": "asia"},
+        session["token"],
+    )
+    print(f"Demo room active: {room['room_id']}", flush=True)
+    heartbeat = args.base + f"/v1/rooms/{room['room_id']}/heartbeat"
+    try:
+        while True:
+            time.sleep(15)
+            headers = {
+                "Authorization": f"Bearer {session['token']}",
+                "Content-Type": "application/json",
+            }
+            operation = urllib.request.Request(
+                heartbeat,
+                data=b'{"state":"waiting"}',
+                headers=headers,
+                method="PUT",
+            )
+            with urllib.request.urlopen(operation, timeout=3):
+                pass
+    except KeyboardInterrupt:
+        print("Demo room stopped.")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/lobby/server.py
+++ b/services/lobby/server.py
@@ -1,0 +1,701 @@
+#!/usr/bin/env python3
+"""Small, dependency-free public-lobby service for MeleePad.
+
+This service discovers compatible traversal rooms; it never proxies gameplay.
+Run it behind an HTTPS reverse proxy outside local development.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import re
+import secrets
+import socketserver
+import threading
+import time
+import urllib.parse
+import uuid
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Callable
+
+
+MAX_BODY_BYTES = 8 * 1024
+SESSION_TTL_SECONDS = 2 * 60 * 60
+ROOM_TTL_SECONDS = 45
+RESERVATION_TTL_SECONDS = 20
+MAX_ROOMS = 500
+MAX_MESSAGES_PER_ROOM = 50
+QUICK_MESSAGE_LIMIT = 4
+QUICK_MESSAGE_WINDOW_SECONDS = 10
+GENERAL_REQUEST_LIMIT = 120
+GENERAL_REQUEST_WINDOW_SECONDS = 60
+
+PROTOCOL_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+VERSION_PATTERN = re.compile(r"^[A-Za-z0-9.+-]{1,32}$")
+GAME_PATTERN = re.compile(r"^[A-Z0-9-]{1,24}$")
+ROOM_CODE_PATTERN = re.compile(r"^[0-9a-f]{8}$")
+DISPLAY_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._-]{0,19}$")
+REGIONS = {"auto", "north-america", "europe", "asia", "oceania", "other"}
+ROOM_STATES = {"waiting", "in_game"}
+REPORT_REASONS = {"offensive_name", "harassment", "spam", "other"}
+QUICK_MESSAGES = {
+    "hello": "Hello!",
+    "ready": "Ready when you are.",
+    "moment": "One moment, please.",
+    "good_luck": "Good luck—have fun!",
+    "good_games": "Good games!",
+    "rematch": "Rematch?",
+}
+BLOCKED_NAME_FRAGMENTS = {
+    "nigger",
+    "faggot",
+    "kike",
+}
+
+
+class LobbyError(Exception):
+    def __init__(self, status: int, code: str, message: str):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+
+
+@dataclass
+class Session:
+    session_id: str
+    token_hash: bytes
+    display_name: str
+    app_version: str
+    build: str
+    protocol: str
+    game_id: str
+    game_revision: str
+    expires_at: float
+    blocked_sessions: set[str] = field(default_factory=set)
+
+
+@dataclass
+class Room:
+    room_id: str
+    owner_session_id: str
+    traversal_code: str
+    region: str
+    created_at: float
+    last_heartbeat: float
+    state: str = "waiting"
+    reservations: dict[str, float] = field(default_factory=dict)
+    messages: deque[dict[str, Any]] = field(
+        default_factory=lambda: deque(maxlen=MAX_MESSAGES_PER_ROOM)
+    )
+    next_message_id: int = 1
+
+
+class SlidingWindowLimiter:
+    def __init__(self, limit: int, window_seconds: float):
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._events: dict[str, deque[float]] = defaultdict(deque)
+
+    def allow(self, key: str, now: float) -> bool:
+        events = self._events[key]
+        cutoff = now - self.window_seconds
+        while events and events[0] <= cutoff:
+            events.popleft()
+        if len(events) >= self.limit:
+            return False
+        events.append(now)
+        return True
+
+
+class LobbyStore:
+    def __init__(self, now: Callable[[], float] = time.time):
+        self._now = now
+        self._lock = threading.RLock()
+        self._sessions: dict[str, Session] = {}
+        self._token_sessions: dict[bytes, str] = {}
+        self._rooms: dict[str, Room] = {}
+        self._reports: deque[dict[str, Any]] = deque(maxlen=1000)
+        self._quick_message_limits = SlidingWindowLimiter(
+            QUICK_MESSAGE_LIMIT, QUICK_MESSAGE_WINDOW_SECONDS
+        )
+        self._request_limits = SlidingWindowLimiter(
+            GENERAL_REQUEST_LIMIT, GENERAL_REQUEST_WINDOW_SECONDS
+        )
+
+    def _purge(self) -> None:
+        now = self._now()
+        expired_sessions = [
+            session_id
+            for session_id, session in self._sessions.items()
+            if session.expires_at <= now
+        ]
+        for session_id in expired_sessions:
+            session = self._sessions.pop(session_id)
+            self._token_sessions.pop(session.token_hash, None)
+        expired_rooms: list[str] = []
+        for room_id, room in self._rooms.items():
+            room.reservations = {
+                session_id: expiry
+                for session_id, expiry in room.reservations.items()
+                if expiry > now and session_id in self._sessions
+            }
+            if (
+                room.owner_session_id not in self._sessions
+                or room.last_heartbeat + ROOM_TTL_SECONDS <= now
+            ):
+                expired_rooms.append(room_id)
+        for room_id in expired_rooms:
+            self._rooms.pop(room_id, None)
+
+    @staticmethod
+    def _token_hash(token: str) -> bytes:
+        return hashlib.sha256(token.encode("ascii")).digest()
+
+    @staticmethod
+    def _required_string(
+        payload: dict[str, Any], key: str, pattern: re.Pattern[str]
+    ) -> str:
+        value = payload.get(key)
+        if not isinstance(value, str) or not pattern.fullmatch(value):
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_FIELD", key)
+        return value
+
+    @staticmethod
+    def _reject_unknown(payload: dict[str, Any], allowed: set[str]) -> None:
+        if not payload.keys() <= allowed:
+            raise LobbyError(
+                HTTPStatus.BAD_REQUEST,
+                "UNKNOWN_FIELD",
+                "Request contains an unsupported field.",
+            )
+
+    @staticmethod
+    def _validate_display_name(payload: dict[str, Any]) -> str:
+        name = LobbyStore._required_string(payload, "display_name", DISPLAY_NAME_PATTERN)
+        folded = name.casefold().replace(" ", "")
+        if any(fragment in folded for fragment in BLOCKED_NAME_FRAGMENTS):
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "NAME_REJECTED", "display_name")
+        return name
+
+    def create_session(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self._reject_unknown(
+            payload,
+            {
+                "display_name",
+                "app_version",
+                "build",
+                "protocol",
+                "game_id",
+                "game_revision",
+            },
+        )
+        display_name = self._validate_display_name(payload)
+        app_version = self._required_string(payload, "app_version", VERSION_PATTERN)
+        build = self._required_string(payload, "build", VERSION_PATTERN)
+        protocol = self._required_string(payload, "protocol", PROTOCOL_PATTERN)
+        game_id = self._required_string(payload, "game_id", GAME_PATTERN)
+        game_revision = self._required_string(payload, "game_revision", VERSION_PATTERN)
+        token = secrets.token_urlsafe(32)
+        session_id = uuid.uuid4().hex
+        expires_at = self._now() + SESSION_TTL_SECONDS
+        session = Session(
+            session_id=session_id,
+            token_hash=self._token_hash(token),
+            display_name=display_name,
+            app_version=app_version,
+            build=build,
+            protocol=protocol,
+            game_id=game_id,
+            game_revision=game_revision,
+            expires_at=expires_at,
+        )
+        with self._lock:
+            self._purge()
+            self._sessions[session_id] = session
+            self._token_sessions[session.token_hash] = session_id
+        return {
+            "session_id": session_id,
+            "token": token,
+            "expires_in": SESSION_TTL_SECONDS,
+        }
+
+    def authenticate(self, token: str | None) -> Session:
+        if not token or len(token) > 128:
+            raise LobbyError(HTTPStatus.UNAUTHORIZED, "AUTH_REQUIRED", "Sign in again.")
+        candidate_hash = self._token_hash(token)
+        with self._lock:
+            self._purge()
+            session_id = self._token_sessions.get(candidate_hash)
+            if session_id is None:
+                raise LobbyError(HTTPStatus.UNAUTHORIZED, "AUTH_INVALID", "Session expired.")
+            session = self._sessions.get(session_id)
+            if session is None or not hmac.compare_digest(
+                session.token_hash, candidate_hash
+            ):
+                raise LobbyError(HTTPStatus.UNAUTHORIZED, "AUTH_INVALID", "Session expired.")
+            return session
+
+    @staticmethod
+    def _compatibility(host: Session, guest: Session) -> tuple[bool, str]:
+        checks = (
+            (host.game_id, guest.game_id, "Different game"),
+            (host.game_revision, guest.game_revision, "Different game revision"),
+            (host.protocol, guest.protocol, "Different netplay protocol"),
+            (host.app_version, guest.app_version, "Different MeleePad version"),
+            (host.build, guest.build, "Different MeleePad build"),
+        )
+        for expected, actual, reason in checks:
+            if expected != actual:
+                return False, reason
+        return True, "Compatible"
+
+    def _players(self, room: Room) -> int:
+        return 1 + len(room.reservations)
+
+    def create_room(self, session: Session, payload: dict[str, Any]) -> dict[str, Any]:
+        self._reject_unknown(payload, {"traversal_code", "region"})
+        traversal_code = self._required_string(
+            payload, "traversal_code", ROOM_CODE_PATTERN
+        )
+        region = payload.get("region", "auto")
+        if region not in REGIONS:
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_REGION", "region")
+        now = self._now()
+        room = Room(
+            room_id=uuid.uuid4().hex,
+            owner_session_id=session.session_id,
+            traversal_code=traversal_code,
+            region=region,
+            created_at=now,
+            last_heartbeat=now,
+        )
+        with self._lock:
+            self._purge()
+            if len(self._rooms) >= MAX_ROOMS:
+                raise LobbyError(
+                    HTTPStatus.SERVICE_UNAVAILABLE, "LOBBY_FULL", "Try again shortly."
+                )
+            for existing_id, existing in list(self._rooms.items()):
+                if existing.owner_session_id == session.session_id:
+                    self._rooms.pop(existing_id, None)
+            self._rooms[room.room_id] = room
+        return {"room_id": room.room_id, "heartbeat_after": 15}
+
+    def room_list(self, guest: Session) -> dict[str, Any]:
+        with self._lock:
+            self._purge()
+            rooms: list[dict[str, Any]] = []
+            for room in sorted(
+                self._rooms.values(), key=lambda item: item.created_at, reverse=True
+            ):
+                if room.owner_session_id in guest.blocked_sessions:
+                    continue
+                host = self._sessions.get(room.owner_session_id)
+                if host is None:
+                    continue
+                compatible, reason = self._compatibility(host, guest)
+                rooms.append(
+                    {
+                        "room_id": room.room_id,
+                        "host_id": host.session_id,
+                        "host": host.display_name,
+                        "region": room.region,
+                        "players": self._players(room),
+                        "capacity": 2,
+                        "state": room.state,
+                        "app_version": host.app_version,
+                        "build": host.build,
+                        "protocol": host.protocol,
+                        "game_id": host.game_id,
+                        "game_revision": host.game_revision,
+                        "compatible": compatible,
+                        "compatibility": reason,
+                    }
+                )
+            return {"rooms": rooms, "server_time": int(self._now())}
+
+    def heartbeat(
+        self, session: Session, room_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        self._reject_unknown(payload, {"state"})
+        state = payload.get("state", "waiting")
+        if state not in ROOM_STATES:
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_STATE", "state")
+        with self._lock:
+            self._purge()
+            room = self._owned_room(session, room_id)
+            room.last_heartbeat = self._now()
+            room.state = state
+            return {"ok": True, "players": self._players(room)}
+
+    def join_room(self, session: Session, room_id: str) -> dict[str, Any]:
+        with self._lock:
+            self._purge()
+            room = self._room(room_id)
+            host = self._sessions.get(room.owner_session_id)
+            if host is None:
+                raise LobbyError(HTTPStatus.NOT_FOUND, "ROOM_GONE", "Room expired.")
+            if room.owner_session_id in session.blocked_sessions:
+                raise LobbyError(HTTPStatus.NOT_FOUND, "ROOM_GONE", "Room unavailable.")
+            compatible, reason = self._compatibility(host, session)
+            if not compatible:
+                raise LobbyError(HTTPStatus.CONFLICT, "INCOMPATIBLE", reason)
+            if room.state != "waiting":
+                raise LobbyError(HTTPStatus.CONFLICT, "GAME_RUNNING", "Match started.")
+            if session.session_id != room.owner_session_id:
+                if (
+                    session.session_id not in room.reservations
+                    and self._players(room) >= 2
+                ):
+                    raise LobbyError(HTTPStatus.CONFLICT, "ROOM_FULL", "Room is full.")
+                room.reservations[session.session_id] = (
+                    self._now() + RESERVATION_TTL_SECONDS
+                )
+            return {
+                "room_id": room.room_id,
+                "traversal_code": room.traversal_code,
+                "host": host.display_name,
+                "reservation_expires_in": RESERVATION_TTL_SECONDS,
+            }
+
+    def heartbeat_member(self, session: Session, room_id: str) -> dict[str, Any]:
+        with self._lock:
+            self._purge()
+            room = self._room(room_id)
+            if room.owner_session_id == session.session_id:
+                raise LobbyError(
+                    HTTPStatus.BAD_REQUEST, "HOST_USES_ROOM_HEARTBEAT", "Invalid role."
+                )
+            if session.session_id not in room.reservations:
+                raise LobbyError(
+                    HTTPStatus.FORBIDDEN, "ROOM_ACCESS", "Join the room again."
+                )
+            room.reservations[session.session_id] = self._now() + ROOM_TTL_SECONDS
+            return {"ok": True, "heartbeat_after": 15}
+
+    def leave_room(self, session: Session, room_id: str) -> dict[str, Any]:
+        with self._lock:
+            room = self._room(room_id)
+            room.reservations.pop(session.session_id, None)
+            return {"ok": True}
+
+    def delete_room(self, session: Session, room_id: str) -> dict[str, Any]:
+        with self._lock:
+            self._owned_room(session, room_id)
+            self._rooms.pop(room_id, None)
+            return {"ok": True}
+
+    def send_message(
+        self, session: Session, room_id: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        self._reject_unknown(payload, {"kind"})
+        kind = payload.get("kind")
+        if kind not in QUICK_MESSAGES:
+            raise LobbyError(
+                HTTPStatus.BAD_REQUEST,
+                "INVALID_MESSAGE",
+                "Only preset quick-chat messages are accepted.",
+            )
+        now = self._now()
+        with self._lock:
+            self._purge()
+            room = self._room(room_id)
+            self._require_membership(session, room)
+            if not self._quick_message_limits.allow(session.session_id, now):
+                raise LobbyError(
+                    HTTPStatus.TOO_MANY_REQUESTS,
+                    "RATE_LIMITED",
+                    "Wait before sending another message.",
+                )
+            message = {
+                "id": room.next_message_id,
+                "sender_id": session.session_id,
+                "sender": session.display_name,
+                "kind": kind,
+                "text": QUICK_MESSAGES[kind],
+                "created_at": int(now),
+            }
+            room.next_message_id += 1
+            room.messages.append(message)
+            return message
+
+    def messages(self, session: Session, room_id: str, after: int) -> dict[str, Any]:
+        with self._lock:
+            self._purge()
+            room = self._room(room_id)
+            self._require_membership(session, room)
+            messages = [
+                message
+                for message in room.messages
+                if message["id"] > after
+                and message["sender_id"] not in session.blocked_sessions
+            ]
+            return {"messages": messages}
+
+    def block(self, session: Session, payload: dict[str, Any]) -> dict[str, Any]:
+        self._reject_unknown(payload, {"session_id"})
+        target = payload.get("session_id")
+        if not isinstance(target, str) or not re.fullmatch(r"[0-9a-f]{32}", target):
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_TARGET", "session_id")
+        if target == session.session_id:
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_TARGET", "session_id")
+        with self._lock:
+            session.blocked_sessions.add(target)
+        return {"ok": True}
+
+    def report(self, session: Session, payload: dict[str, Any]) -> dict[str, Any]:
+        self._reject_unknown(payload, {"session_id", "room_id", "reason"})
+        target = payload.get("session_id")
+        room_id = payload.get("room_id")
+        reason = payload.get("reason")
+        if not isinstance(target, str) or not re.fullmatch(r"[0-9a-f]{32}", target):
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_TARGET", "session_id")
+        if not isinstance(room_id, str) or not re.fullmatch(r"[0-9a-f]{32}", room_id):
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_ROOM", "room_id")
+        if reason not in REPORT_REASONS:
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_REASON", "reason")
+        with self._lock:
+            self._reports.append(
+                {
+                    "reporter": session.session_id,
+                    "target": target,
+                    "room_id": room_id,
+                    "reason": reason,
+                    "created_at": int(self._now()),
+                }
+            )
+            session.blocked_sessions.add(target)
+        return {"accepted": True}
+
+    def allow_request(self, key: str) -> bool:
+        with self._lock:
+            return self._request_limits.allow(key, self._now())
+
+    def _room(self, room_id: str) -> Room:
+        room = self._rooms.get(room_id)
+        if room is None:
+            raise LobbyError(HTTPStatus.NOT_FOUND, "ROOM_GONE", "Room expired.")
+        return room
+
+    def _owned_room(self, session: Session, room_id: str) -> Room:
+        room = self._room(room_id)
+        if room.owner_session_id != session.session_id:
+            raise LobbyError(HTTPStatus.FORBIDDEN, "HOST_ONLY", "Host access required.")
+        return room
+
+    @staticmethod
+    def _require_membership(session: Session, room: Room) -> None:
+        if (
+            room.owner_session_id != session.session_id
+            and session.session_id not in room.reservations
+        ):
+            raise LobbyError(HTTPStatus.FORBIDDEN, "ROOM_ACCESS", "Join the room first.")
+
+
+class LobbyHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+    request_queue_size = 128
+
+    def __init__(self, address: tuple[str, int], store: LobbyStore):
+        super().__init__(address, LobbyHandler)
+        self.store = store
+
+    def server_bind(self) -> None:
+        # HTTPServer performs a reverse-DNS lookup during bind. It is not used
+        # by this API and can stall startup on hosts without working DNS.
+        socketserver.TCPServer.server_bind(self)
+        self.server_name = str(self.server_address[0])
+        self.server_port = int(self.server_address[1])
+
+
+class LobbyHandler(BaseHTTPRequestHandler):
+    server: LobbyHTTPServer
+    # One request per connection keeps the stdlib development server bounded
+    # and avoids tying up worker threads on idle keep-alive sockets.
+    protocol_version = "HTTP/1.0"
+
+    def log_message(self, _format: str, *args: Any) -> None:
+        # The standard handler logs client IPs. Lobby diagnostics intentionally
+        # exclude IP addresses, tokens, traversal codes, and message contents.
+        return
+
+    def _send(self, status: int, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.close_connection = True
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def _payload(self) -> dict[str, Any]:
+        content_type = self.headers.get("Content-Type", "")
+        if content_type.split(";", 1)[0].strip() != "application/json":
+            raise LobbyError(
+                HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                "JSON_REQUIRED",
+                "Use application/json.",
+            )
+        raw_length = self.headers.get("Content-Length")
+        try:
+            length = int(raw_length or "0")
+        except ValueError as error:
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_LENGTH", "Invalid body.") from error
+        if length <= 0 or length > MAX_BODY_BYTES:
+            raise LobbyError(
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                "BODY_SIZE",
+                "Request body is too large.",
+            )
+        try:
+            payload = json.loads(self.rfile.read(length))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_JSON", "Invalid JSON.") from error
+        if not isinstance(payload, dict):
+            raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_JSON", "Object required.")
+        return payload
+
+    def _token(self) -> str | None:
+        authorization = self.headers.get("Authorization", "")
+        if not authorization.startswith("Bearer "):
+            return None
+        return authorization[7:]
+
+    def _session(self) -> Session:
+        return self.server.store.authenticate(self._token())
+
+    def _dispatch(self, method: str) -> None:
+        client_key = self.client_address[0]
+        if not self.server.store.allow_request(client_key):
+            raise LobbyError(
+                HTTPStatus.TOO_MANY_REQUESTS, "RATE_LIMITED", "Try again shortly."
+            )
+        parsed = urllib.parse.urlsplit(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        query = urllib.parse.parse_qs(parsed.query)
+        store = self.server.store
+
+        if method == "GET" and path == "/healthz":
+            self._send(HTTPStatus.OK, {"status": "ok"})
+            return
+        if method == "POST" and path == "/v1/sessions":
+            self._send(HTTPStatus.CREATED, store.create_session(self._payload()))
+            return
+
+        session = self._session()
+        if method == "GET" and path == "/v1/rooms":
+            self._send(HTTPStatus.OK, store.room_list(session))
+            return
+        if method == "POST" and path == "/v1/rooms":
+            self._send(HTTPStatus.CREATED, store.create_room(session, self._payload()))
+            return
+        if method == "POST" and path == "/v1/blocks":
+            self._send(HTTPStatus.OK, store.block(session, self._payload()))
+            return
+        if method == "POST" and path == "/v1/reports":
+            self._send(HTTPStatus.ACCEPTED, store.report(session, self._payload()))
+            return
+
+        match = re.fullmatch(r"/v1/rooms/([0-9a-f]{32})/heartbeat", path)
+        if match and method == "PUT":
+            self._send(
+                HTTPStatus.OK,
+                store.heartbeat(session, match.group(1), self._payload()),
+            )
+            return
+        match = re.fullmatch(r"/v1/rooms/([0-9a-f]{32})/join", path)
+        if match and method == "POST":
+            payload = self._payload()
+            store._reject_unknown(payload, set())
+            self._send(HTTPStatus.OK, store.join_room(session, match.group(1)))
+            return
+        match = re.fullmatch(r"/v1/rooms/([0-9a-f]{32})/members/me", path)
+        if match and method == "DELETE":
+            self._send(HTTPStatus.OK, store.leave_room(session, match.group(1)))
+            return
+        match = re.fullmatch(
+            r"/v1/rooms/([0-9a-f]{32})/members/me/heartbeat", path
+        )
+        if match and method == "PUT":
+            payload = self._payload()
+            store._reject_unknown(payload, set())
+            self._send(HTTPStatus.OK, store.heartbeat_member(session, match.group(1)))
+            return
+        match = re.fullmatch(r"/v1/rooms/([0-9a-f]{32})/messages", path)
+        if match and method == "POST":
+            self._send(
+                HTTPStatus.CREATED,
+                store.send_message(session, match.group(1), self._payload()),
+            )
+            return
+        if match and method == "GET":
+            try:
+                after = max(0, int(query.get("after", ["0"])[0]))
+            except ValueError as error:
+                raise LobbyError(HTTPStatus.BAD_REQUEST, "INVALID_CURSOR", "after") from error
+            self._send(HTTPStatus.OK, store.messages(session, match.group(1), after))
+            return
+        match = re.fullmatch(r"/v1/rooms/([0-9a-f]{32})", path)
+        if match and method == "DELETE":
+            self._send(HTTPStatus.OK, store.delete_room(session, match.group(1)))
+            return
+
+        raise LobbyError(HTTPStatus.NOT_FOUND, "NOT_FOUND", "Endpoint not found.")
+
+    def _handle(self, method: str) -> None:
+        try:
+            self._dispatch(method)
+        except LobbyError as error:
+            self._send(
+                error.status,
+                {"error": {"code": error.code, "message": error.message}},
+            )
+        except (BrokenPipeError, ConnectionResetError):
+            return
+        except Exception:
+            self._send(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"error": {"code": "INTERNAL", "message": "Request failed."}},
+            )
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._handle("GET")
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._handle("POST")
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self._handle("PUT")
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self._handle("DELETE")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MeleePad public-lobby service")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args()
+    server = LobbyHTTPServer((args.host, args.port), LobbyStore())
+    print(f"MeleePad lobby listening on {args.host}:{server.server_port}")
+    try:
+        server.serve_forever(poll_interval=0.25)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/lobby/test_server.py
+++ b/services/lobby/test_server.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+import urllib.error
+import urllib.request
+
+from services.lobby.server import LobbyHTTPServer, LobbyStore, QUICK_MESSAGE_LIMIT
+
+
+class LobbyServiceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server = LobbyHTTPServer(("127.0.0.1", 0), LobbyStore())
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.base = f"http://127.0.0.1:{cls.server.server_port}"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Avoid BaseServer.shutdown's platform-dependent wait when the test
+        # runner tears down an otherwise idle loopback server.
+        cls.server._BaseServer__shutdown_request = True
+        cls.server.server_close()
+        cls.thread.join(timeout=2)
+
+    def request(self, method, path, payload=None, token=None, expected=200):
+        data = None if payload is None else json.dumps(payload).encode()
+        headers = {"Connection": "close"}
+        if payload is not None:
+            headers["Content-Type"] = "application/json"
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        request = urllib.request.Request(
+            self.base + path, data=data, headers=headers, method=method
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=2) as response:
+                self.assertEqual(expected, response.status)
+                self.assertEqual("no-store", response.headers["Cache-Control"])
+                return json.load(response)
+        except urllib.error.HTTPError as error:
+            self.assertEqual(expected, error.code)
+            return json.load(error)
+
+    def session(self, name, build="4"):
+        return self.request(
+            "POST",
+            "/v1/sessions",
+            {
+                "display_name": name,
+                "app_version": "0.1.0",
+                "build": build,
+                "protocol": "moderngekko-netplay-8",
+                "game_id": "GALE01",
+                "game_revision": "r0",
+            },
+            expected=201,
+        )
+
+    def test_health_does_not_require_authentication(self):
+        self.assertEqual(
+            {"status": "ok"}, self.request("GET", "/healthz", expected=200)
+        )
+
+    def test_room_code_is_hidden_until_compatible_join(self):
+        host = self.session("Host")
+        room = self.request(
+            "POST",
+            "/v1/rooms",
+            {"traversal_code": "1234abcd", "region": "asia"},
+            host["token"],
+            201,
+        )
+        guest = self.session("Guest")
+        listing = self.request("GET", "/v1/rooms", token=guest["token"])
+        card = next(item for item in listing["rooms"] if item["room_id"] == room["room_id"])
+        self.assertTrue(card["compatible"])
+        self.assertNotIn("traversal_code", card)
+        joined = self.request(
+            "POST", f"/v1/rooms/{room['room_id']}/join", {}, guest["token"]
+        )
+        self.assertEqual("1234abcd", joined["traversal_code"])
+
+    def test_incompatible_build_is_visible_but_cannot_join(self):
+        host = self.session("VersionHost")
+        room = self.request(
+            "POST",
+            "/v1/rooms",
+            {"traversal_code": "aabbccdd", "region": "auto"},
+            host["token"],
+            201,
+        )
+        guest = self.session("OldBuild", build="3")
+        listing = self.request("GET", "/v1/rooms", token=guest["token"])
+        card = next(item for item in listing["rooms"] if item["room_id"] == room["room_id"])
+        self.assertFalse(card["compatible"])
+        self.assertEqual("Different MeleePad build", card["compatibility"])
+        failure = self.request(
+            "POST", f"/v1/rooms/{room['room_id']}/join", {}, guest["token"], 409
+        )
+        self.assertEqual("INCOMPATIBLE", failure["error"]["code"])
+
+    def test_quick_chat_rejects_free_text_and_rate_limits(self):
+        host = self.session("ChatHost")
+        room = self.request(
+            "POST",
+            "/v1/rooms",
+            {"traversal_code": "deadbeef", "region": "europe"},
+            host["token"],
+            201,
+        )
+        rejected = self.request(
+            "POST",
+            f"/v1/rooms/{room['room_id']}/messages",
+            {"kind": "custom", "text": "unbounded content"},
+            host["token"],
+            400,
+        )
+        self.assertEqual("UNKNOWN_FIELD", rejected["error"]["code"])
+        for _ in range(QUICK_MESSAGE_LIMIT):
+            self.request(
+                "POST",
+                f"/v1/rooms/{room['room_id']}/messages",
+                {"kind": "ready"},
+                host["token"],
+                201,
+            )
+        limited = self.request(
+            "POST",
+            f"/v1/rooms/{room['room_id']}/messages",
+            {"kind": "hello"},
+            host["token"],
+            429,
+        )
+        self.assertEqual("RATE_LIMITED", limited["error"]["code"])
+
+    def test_report_also_hides_reported_hosts(self):
+        host = self.session("ReportedHost")
+        room = self.request(
+            "POST",
+            "/v1/rooms",
+            {"traversal_code": "cafebabe", "region": "other"},
+            host["token"],
+            201,
+        )
+        guest = self.session("Reporter")
+        listing = self.request("GET", "/v1/rooms", token=guest["token"])
+        card = next(item for item in listing["rooms"] if item["room_id"] == room["room_id"])
+        result = self.request(
+            "POST",
+            "/v1/reports",
+            {
+                "session_id": card["host_id"],
+                "room_id": card["room_id"],
+                "reason": "offensive_name",
+            },
+            guest["token"],
+            202,
+        )
+        self.assertTrue(result["accepted"])
+        listing = self.request("GET", "/v1/rooms", token=guest["token"])
+        self.assertNotIn(room["room_id"], {item["room_id"] for item in listing["rooms"]})
+
+    def test_host_only_heartbeat_and_delete(self):
+        host = self.session("Owner")
+        room = self.request(
+            "POST",
+            "/v1/rooms",
+            {"traversal_code": "01020304", "region": "north-america"},
+            host["token"],
+            201,
+        )
+        guest = self.session("NotOwner")
+        denied = self.request(
+            "PUT",
+            f"/v1/rooms/{room['room_id']}/heartbeat",
+            {"state": "waiting"},
+            guest["token"],
+            403,
+        )
+        self.assertEqual("HOST_ONLY", denied["error"]["code"])
+        self.request(
+            "PUT",
+            f"/v1/rooms/{room['room_id']}/heartbeat",
+            {"state": "in_game"},
+            host["token"],
+        )
+        self.request("DELETE", f"/v1/rooms/{room['room_id']}", token=host["token"])
+
+    def test_full_room_and_nonmember_messages_fail_closed(self):
+        host = self.session("FullHost")
+        room = self.request(
+            "POST",
+            "/v1/rooms",
+            {"traversal_code": "11223344", "region": "oceania"},
+            host["token"],
+            201,
+        )
+        guest = self.session("FirstGuest")
+        outsider = self.session("Outsider")
+        self.request("POST", f"/v1/rooms/{room['room_id']}/join", {}, guest["token"])
+        full = self.request(
+            "POST", f"/v1/rooms/{room['room_id']}/join", {}, outsider["token"], 409
+        )
+        self.assertEqual("ROOM_FULL", full["error"]["code"])
+        denied = self.request(
+            "GET", f"/v1/rooms/{room['room_id']}/messages", token=outsider["token"], expected=403
+        )
+        self.assertEqual("ROOM_ACCESS", denied["error"]["code"])
+
+    def test_stale_rooms_expire(self):
+        now = [100.0]
+        store = LobbyStore(now=lambda: now[0])
+        payload = {
+            "display_name": "ExpiryHost",
+            "app_version": "0.1.0",
+            "build": "4",
+            "protocol": "moderngekko-netplay-8",
+            "game_id": "GALE01",
+            "game_revision": "r0",
+        }
+        host_token = store.create_session(payload)["token"]
+        guest_payload = dict(payload)
+        guest_payload["display_name"] = "ExpiryGuest"
+        guest_token = store.create_session(guest_payload)["token"]
+        host = store.authenticate(host_token)
+        guest = store.authenticate(guest_token)
+        store.create_room(host, {"traversal_code": "55667788", "region": "auto"})
+        self.assertEqual(1, len(store.room_list(guest)["rooms"]))
+        now[0] += 46
+        self.assertEqual([], store.room_list(guest)["rooms"])
+
+    def test_joined_guest_can_extend_presence(self):
+        now = [100.0]
+        store = LobbyStore(now=lambda: now[0])
+        base = {
+            "app_version": "0.1.0",
+            "build": "4",
+            "protocol": "moderngekko-netplay-8",
+            "game_id": "GALE01",
+            "game_revision": "r0",
+        }
+        host_token = store.create_session({**base, "display_name": "PresenceHost"})["token"]
+        guest_token = store.create_session({**base, "display_name": "PresenceGuest"})["token"]
+        host = store.authenticate(host_token)
+        guest = store.authenticate(guest_token)
+        room = store.create_room(
+            host, {"traversal_code": "99aabbcc", "region": "auto"}
+        )
+        store.join_room(guest, room["room_id"])
+        now[0] += 15
+        store.heartbeat_member(guest, room["room_id"])
+        now[0] += 10
+        message = store.send_message(guest, room["room_id"], {"kind": "hello"})
+        self.assertEqual("Hello!", message["text"])
+
+    def test_auth_and_input_validation_fail_closed(self):
+        missing = self.request("GET", "/v1/rooms", expected=401)
+        self.assertEqual("AUTH_REQUIRED", missing["error"]["code"])
+        rejected = self.request(
+            "POST",
+            "/v1/sessions",
+            {
+                "display_name": "bad/name",
+                "app_version": "0.1.0",
+                "build": "4",
+                "protocol": "moderngekko-netplay-8",
+                "game_id": "GALE01",
+                "game_revision": "r0",
+            },
+            expected=400,
+        )
+        self.assertEqual("INVALID_FIELD", rejected["error"]["code"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test-ios-online-play-lobby.sh
+++ b/tests/test-ios-online-play-lobby.sh
@@ -7,6 +7,8 @@ OVERLAY_HEADER="$ROOT/apple/ios/MeleePadGameOverlay.h"
 CONTROLLER="$ROOT/apple/ios/MeleePadGameViewController.mm"
 LOBBY="$ROOT/apple/ios/MeleePadOnlinePlayViewController.mm"
 LOBBY_HEADER="$ROOT/apple/ios/MeleePadOnlinePlayViewController.h"
+PUBLIC_CLIENT="$ROOT/apple/ios/MeleePadPublicLobbyClient.m"
+PUBLIC_CLIENT_HEADER="$ROOT/apple/ios/MeleePadPublicLobbyClient.h"
 PROJECT="$ROOT/MeleePad.xcodeproj/project.pbxproj"
 CORE="$ROOT/apple/ios/MeleePadCoreHost.mm"
 CORE_HEADER="$ROOT/apple/ios/MeleePadCoreHost.h"
@@ -14,7 +16,7 @@ BUILD_CORE="$ROOT/scripts/ios-build-core.sh"
 PROVISION="$ROOT/scripts/ios-provision.sh"
 INFO="$ROOT/apple/ios/Info.plist"
 
-for file in "$LOBBY" "$LOBBY_HEADER"; do
+for file in "$LOBBY" "$LOBBY_HEADER" "$PUBLIC_CLIENT" "$PUBLIC_CLIENT_HEADER"; do
   [[ -f "$file" ]] || {
     echo "native Online Play lobby is missing: $file" >&2
     exit 1
@@ -39,19 +41,25 @@ for contract in \
 done
 
 for contract in \
-  '@"Experimental Multiplayer"' \
-  '@"Direct Peer Connection"' \
-  'Each device runs the same Melee match locally and exchanges controller input' \
-  'There are no room codes or matchmaking servers yet' \
-  'complete matches are not yet reliable.' \
+  '@"Online Play"' \
+  '@"Play MeleePad Together"' \
+  '@"Public Games"' \
+  '@"Private Room"' \
+  'eight-character room code' \
+  '@"Direct IP"' \
+  'address = address.lowercaseString' \
+  'hexadecimal characters' \
   '@"Host"' \
   '@"Join"' \
   '@"Nickname"' \
   '@"Host IP or hostname"' \
   '@"UDP port (default 2626)"' \
-  "2626 is Dolphin's standard direct-NetPlay UDP port, not a server address." \
+  "Dolphin's public traversal service" \
   '@"Automatic input buffer"' \
   '@"Players"' \
+  '@"Quick chat"' \
+  '@"Hide Player"' \
+  '@"Report Offensive Name"' \
   'Compatibility: %@' \
   '@"Ready"' \
   '@"Start Match"' \
@@ -66,10 +74,25 @@ fi
 
 grep -Fq 'MeleePadOnlinePlayViewController.mm in Sources' "$PROJECT"
 grep -Fq 'MeleePadOnlinePlayViewController.h' "$PROJECT"
+grep -Fq 'MeleePadPublicLobbyClient.m in Sources' "$PROJECT"
+grep -Fq 'MeleePadPublicLobbyClient.h' "$PROJECT"
+
+for contract in \
+  'moderngekko-netplay-8' \
+  'MELEEPAD_LOBBY_BASE_URL' \
+  'ephemeralSessionConfiguration' \
+  'HTTPCookieAcceptPolicyNever' \
+  'https' \
+  '127.0.0.1' \
+  '/v1/rooms' \
+  'traversal_code'; do
+  grep -Fq "$contract" "$PUBLIC_CLIENT"
+done
 
 for contract in \
   'beginNetplayHostingWithNickname:' \
   'beginNetplayJoiningAddress:' \
+  'usingTraversal:' \
   'pollNetplayWithCompletion:' \
   'setNetplayReady:' \
   'requestNetplayStart' \
@@ -90,6 +113,10 @@ grep -Fq 'MODERNGEKKO_GAMECUBE_CONTROLLERS=ON' "$BUILD_CORE"
 grep -Fq '<key>NSLocalNetworkUsageDescription</key>' "$INFO"
 if grep -Fq 'native session bridge is not connected' "$CONTROLLER"; then
   echo "Online Play still exposes the disconnected bridge placeholder" >&2
+  exit 1
+fi
+if grep -Fq 'There are no room codes or matchmaking servers yet' "$LOBBY"; then
+  echo "Online Play still claims Internet rooms do not exist" >&2
   exit 1
 fi
 

--- a/tests/test-netplay-canonical-boundary.sh
+++ b/tests/test-netplay-canonical-boundary.sh
@@ -19,8 +19,12 @@ for contract in \
   'canonical-boundary active' \
   'GetNetplayBoundarySnapshot' \
   'HashSelectedRamPages' \
+  'HashSelectedRamRegions' \
+  'ram_region_hashes' \
+  'CANONICAL_RAM_REGION_SIZE' \
+  'CanonicalRamFirstDifferingRegion' \
   'CanonicalStateMatches' \
-  'moderngekko-netplay-7' \
+  'moderngekko-netplay-8' \
   'canonical_sequence=' \
   'canonical_ram_hash=' \
   'canonical-match sequence=' \
@@ -36,7 +40,11 @@ for contract in \
   'add_difference("integer"' \
   'add_difference("fpr"' \
   'add_difference("paired"' \
-  'add_difference("ram"'; do
+  'add_difference("ram"' \
+  'timebase_delta=' \
+  'ram_first_region=' \
+  'ram_first_address=' \
+  'canonical_ram_region_hash='; do
   grep -Fq "$contract" "$SUMMARY_PATCH"
 done
 
@@ -51,7 +59,9 @@ for contract in \
   'fpr_state_hash ^=' \
   'paired_state_hash ^=' \
   'timebase ^=' \
-  'ram_hash ^='; do
+  'ram_hash ^=' \
+  'ram_region_hashes[3] ^=' \
+  'CanonicalRamFirstDifferingRegion'; do
   grep -Fq "$contract" "$TEST_PATCH"
 done
 

--- a/tests/test-netplay-internet-rooms.sh
+++ b/tests/test-netplay-internet-rooms.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+PATCH="$ROOT/patches/moderngekko/0020-netplay-internet-rooms.patch"
+BOOTSTRAP="$ROOT/scripts/bootstrap-dependencies.sh"
+
+for contract in \
+  'stun.dolphin-emu.org' \
+  'TRAVERSAL_PORT = 6262' \
+  'TRAVERSAL_PORT_ALT = 6226' \
+  'bool use_traversal = false' \
+  'std::string room_code' \
+  'Common::g_TraversalClient->GetHostID()' \
+  'Internet room connection failed' \
+  '--netplay-room-host' \
+  '--netplay-room-join <code>' \
+  'MELEEPAD_NETPLAY_TRACE_ROOM_CODE'; do
+  grep -Fq -- "$contract" "$PATCH"
+done
+
+grep -Fq '0020-netplay-internet-rooms.patch' "$BOOTSTRAP"
+grep -Fq "'stun.dolphin-emu.org'" "$BOOTSTRAP"
+
+echo "Netplay Internet-room source contract passed"

--- a/tests/test-public-lobby.sh
+++ b/tests/test-public-lobby.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+SERVER="$ROOT/services/lobby/server.py"
+CLIENT="$ROOT/apple/ios/MeleePadPublicLobbyClient.m"
+DESIGN="$ROOT/docs/PUBLIC-LOBBY-DESIGN.md"
+
+for file in "$SERVER" "$CLIENT" "$DESIGN"; do
+  [[ -f "$file" ]] || {
+    echo "public-lobby component is missing: $file" >&2
+    exit 1
+  }
+done
+
+for contract in \
+  'MAX_BODY_BYTES = 8 * 1024' \
+  'ROOM_TTL_SECONDS = 45' \
+  'RESERVATION_TTL_SECONDS = 20' \
+  'hashlib.sha256' \
+  'hmac.compare_digest' \
+  'QUICK_MESSAGES' \
+  'REPORT_REASONS' \
+  'Different MeleePad build' \
+  'traversal_code' \
+  'Cache-Control' \
+  'no-store'; do
+  grep -Fq "$contract" "$SERVER"
+done
+
+grep -Fq 'moderngekko-netplay-8' "$CLIENT"
+grep -Fq 'moderngekko-netplay-8' "$ROOT/services/lobby/test_server.py"
+grep -Fq 'traversal code only after compatible join' "$DESIGN"
+
+python3 -m unittest services.lobby.test_server
+
+echo "public lobby security and API contracts passed"


### PR DESCRIPTION
## Summary

- add Preview 2 Private Room traversal codes, Direct IP, strict compatibility/desync diagnostics, and the Public Games development UI
- add the bounded local lobby service with preset quick chat, heartbeat, hide/report, and security limits
- document exactly what network play does and does not support, the post-Preview-2 roadmap, and the sole supported GALE01 revision-0 image
- add reproducible public packaging for an unsigned module-free iOS app shell; generated game code, game data, saves, signatures, profiles, and private paths are rejected
- increment the iOS bundle build to 5

## Verification

- complete repository check suite passed
- clean unsigned generic-iPhoneOS Release build passed
- signed build 5 installed and launched on the physical iPad without changing the existing save, configuration, preferences, ISO, or extracted data
- module-free IPA packaged twice byte-identically
- IPA ZIP, bundle, ARM64, iOS 16 minimum, unsigned state, and prohibited-data audits passed
- public IPA SHA-256: 797a4d9c218650bd6f7377f07d798d5f06ff46abcfee33c8cdbe44248a552519
- the public packager rejected the ignored local module-bearing IPA

## Release boundary

Private Room works through Dolphin public traversal but still requires players to exchange a code elsewhere. Public Games has no production endpoint and remains unavailable. There is no relay, automatic matchmaking, ranked play, or Slippi rollback.

The release IPA is explicitly an unsigned, module-free app shell and is not playable as downloaded. Playable builds remain local-only and require the exact user-supplied supported GALE01 USA revision-0 image.