### PR TITLE
Reduce normal CPU-loop overhead and improve v1.02 profiling

### DIFF
--- a/apple/ios/MeleePadCoreHost.mm
+++ b/apple/ios/MeleePadCoreHost.mm
@@ -379,6 +379,19 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
               userDirectory:(NSString *)userDirectory {
     std::string errorMessage;
     @autoreleasepool {
+        // Developer launch option: reuse the existing profiler without enabling
+        // per-frame tracing in ordinary builds or adding another settings page.
+        if ([NSProcessInfo.processInfo.environment[@"MELEEPAD_PERFORMANCE_CAPTURE"]
+                isEqualToString:@"1"]) {
+            NSString *logs = MeleePadDiagnosticsLogPath().stringByDeletingLastPathComponent;
+            NSString *phasePath = [logs stringByAppendingPathComponent:@"performance-phase.csv"];
+            NSString *dispatchPath = [logs stringByAppendingPathComponent:@"performance-dispatch.csv"];
+            setenv("MELEEPAD_FRAME_PHASE_LOG", phasePath.fileSystemRepresentation, 1);
+            setenv("STATICRECOMP_DISPATCH_TIME_LOG", dispatchPath.fileSystemRepresentation, 1);
+            // A prime interval reduces alignment with repeating dispatch paths.
+            setenv("STATICRECOMP_DISPATCH_SAMPLE_INTERVAL", "4093", 1);
+            MeleePadLog(@"performance capture enabled interval=4093 files=performance-phase.csv,performance-dispatch.csv; diagnostic timing includes observer overhead");
+        }
         NSString *runtimeUserDirectory = MeleePadRuntimeUserDirectory(userDirectory);
         const BOOL offlineCheatsAllowed =
             _allowOfflineCheats->load(std::memory_order_acquire);

--- a/apple/ios/MeleePadCoreHost.mm
+++ b/apple/ios/MeleePadCoreHost.mm
@@ -727,13 +727,17 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
 
 - (MeleePadBenchmarkGuestState)benchmarkGuestState {
     MeleePadBenchmarkGuestState result = {};
-    if (_gameRevision != 0) return result;
-    // Revision-1.00 globals validated from the generated instructions. Read
+    if (_gameRevision != 0 && _gameRevision != 2) return result;
+    // v1.02 globals and layouts are verified against doldecomp/melee
+    // ae5898e symbols, mncharsel.c and mn/types.h; retain v1.00 addresses. Read
     // the active P1 CSS cursor pointer instead of assuming one heap address;
     // different game modes allocate that same cursor at different locations.
-    constexpr u32 kGameStateAddress = 0x80477D68u;
-    constexpr u32 kCursorPointerAddress = 0x8049EA88u;
-    constexpr u32 kCssDataPointerAddress = 0x804D4B30u;
+    const u32 kGameStateAddress = _gameRevision == 2
+        ? 0x80479D30u : 0x80477D68u;
+    const u32 kCursorPointerAddress = _gameRevision == 2
+        ? 0x804A0BC0u : 0x8049EA88u;
+    const u32 kCssDataPointerAddress = _gameRevision == 2
+        ? 0x804D6CB0u : 0x804D4B30u;
     std::scoped_lock lock(*_runtimeMutex);
     if (_runtime == nullptr)
         return result;
@@ -793,12 +797,14 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
 }
 
 - (BOOL)setBenchmarkRandomSeed:(u32)seed previousValue:(u32 *)previousValue {
-    if (_gameRevision != 0) return NO;
-    // The revision-1.00 DOL loads its HSD random-state pointer from r13-22292.
+    if (_gameRevision != 0 && _gameRevision != 2) return NO;
+    // Each revision has its own verified HSD seed and seed_ptr globals.
     // Validate the initialized pointer before making this benchmark-only RAM
-    // write so a different game revision fails closed.
-    constexpr u32 kRandomSeedAddress = 0x804D3E08u;
-    constexpr u32 kRandomSeedPointerAddress = 0x804D3E0Cu;
+    // write so an unexpected initialized layout fails closed.
+    const u32 kRandomSeedAddress = _gameRevision == 2
+        ? 0x804D5F90u : 0x804D3E08u;
+    const u32 kRandomSeedPointerAddress = _gameRevision == 2
+        ? 0x804D5F94u : 0x804D3E0Cu;
     std::scoped_lock lock(*_runtimeMutex);
     if (_runtime == nullptr)
         return NO;
@@ -815,12 +821,13 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
 }
 
 - (BOOL)setBenchmarkForcedStage:(u8)stageId previousValue:(u8 *)previousValue {
-    if (_gameRevision != 0) return NO;
-    // Revision-1.00 stores mnStageSel's active SSSData pointer at r13-18960.
+    if (_gameRevision != 0 && _gameRevision != 2) return NO;
+    // Resolve mnStageSel's active SSSData pointer for the verified revision.
     // Callers additionally gate this write on Training mode's stage-select
     // scene. Validate the pointed-to structure before changing its one signed
     // force_stage_id byte; unexpected revisions and layouts fail closed.
-    constexpr u32 kStageSelectDataPointerAddress = 0x804D4B10u;
+    const u32 kStageSelectDataPointerAddress = _gameRevision == 2
+        ? 0x804D6C90u : 0x804D4B10u;
     std::scoped_lock lock(*_runtimeMutex);
     if (_runtime == nullptr)
         return NO;
@@ -843,13 +850,15 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
 }
 
 - (BOOL)setBenchmarkFourPlayerRosterPreviousValue:(u32 *)previousValue {
-    if (_gameRevision != 0) return NO;
-    // Revision-1.00 stores the active CSSData pointer at r13-18928. The route
+    if (_gameRevision != 0 && _gameRevision != 2) return NO;
+    // Both verified CSSData layouts use players at +0x70, stride 0x24. The route
     // opens every controller door through normal UI input first; this narrow,
     // benchmark-only write then removes random CPU-token overlap while leaving
     // the match rules, port kinds, levels, costumes, and saved data untouched.
-    constexpr u32 kGameStateAddress = 0x80477D68u;
-    constexpr u32 kCssDataPointerAddress = 0x804D4B30u;
+    const u32 kGameStateAddress = _gameRevision == 2
+        ? 0x80479D30u : 0x80477D68u;
+    const u32 kCssDataPointerAddress = _gameRevision == 2
+        ? 0x804D6CB0u : 0x804D4B30u;
     constexpr u32 kFirstPlayerOffset = 0x70u;
     constexpr u32 kPlayerStride = 0x24u;
     constexpr std::array<u8, 4> kRoster = {{0x10u, 0x04u, 0x05u, 0x06u}};

--- a/apple/ios/MeleePadCoreHost.mm
+++ b/apple/ios/MeleePadCoreHost.mm
@@ -823,7 +823,7 @@ static NSString *MeleePadNetplayFailureMessage(moderngekko::frontend::NetplayExi
 - (BOOL)setBenchmarkForcedStage:(u8)stageId previousValue:(u8 *)previousValue {
     if (_gameRevision != 0 && _gameRevision != 2) return NO;
     // Resolve mnStageSel's active SSSData pointer for the verified revision.
-    // Callers additionally gate this write on Training mode's stage-select
+    // Callers additionally gate this write on the route's stage-select
     // scene. Validate the pointed-to structure before changing its one signed
     // force_stage_id byte; unexpected revisions and layouts fail closed.
     const u32 kStageSelectDataPointerAddress = _gameRevision == 2

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -347,3 +347,22 @@ Complete capture files and hashes are `route-control/*-cooled2.*` and
 candidate build 14 was reinstalled without launching it. The matching candidate
 cooldown is in progress. The goal remains incomplete and the experimental
 module remains outside main and any public release.
+
+
+### Cooled candidate: promising aggregate, reject the trig component
+
+After the same five-minute idle interval, candidate build 14 reports nominal
+at startup, unlike the control's initially serious then fair state. Candidate
+CPU means are 14.935, 16.245 and 18.102 ms, respectively 4.02%, 3.56% and 4.65%
+below the cooled control; FPS is 59.88, 58.69 and 52.80. In the latter two
+windows, draws/primitives/cycles/dispatches differ by at most 0.16%. This is
+encouraging aggregate evidence but the starting thermal-state difference
+prevents attributing the full gain to the optimization.
+
+Corrected inclusive entry timing in those latter windows isolates a problem:
+inverse is 648.02 ns control versus 318.23 candidate, but cosine increases
+294.64 to 425.40 ns and sine 270.33 to 313.23 ns. Unchanged reference routines
+move in both directions. Reject the trig component. A revised private module
+is building with inverse plus the correctness-tested scalar matrix-add region,
+restoring the original trig chunk. No further phone build is installed yet;
+build 14 was stopped after saving its capture. Retention remains unproven.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -149,3 +149,49 @@ math timing alone cannot qualify it for a claimed device improvement.
 The final CSVs were copied before restarting the regular app without capture
 environment variables. The unflushed trailing dispatch buffer is deliberately
 not part of the evidence. No new optimization has been installed.
+
+## Matrix-code preflight: deferred result classification
+
+The first code experiment now exists privately and has been executed. It is
+not installed on the iPhone or enabled in the accepted main build.
+
+- Adding a restricted context pointer produced identical ARM64 instruction
+  text in all three screened hot chunks. Rejected without a device build.
+- A guarded direct-RAM version of the inverse-transpose region preserved
+  20,000 CPU-state/RAM comparisons, but improved local time only about 1–3%.
+- Inlining the unchanged FP helpers and hoisting FP-availability checks under
+  a validated no-callback entry improved that local result to roughly 7–11%.
+  This remained too small for a device candidate.
+- Deferring the overwritten FPSCR result-classification field (FPRF) until
+  each exit improved the same local region by **34–38%** in the initial run.
+  An expanded run passed **100,000 adversarial entry comparisons** and
+  measured 37.3–38.6% across seven alternating local timing pairs.
+
+The final expanded run compares complete CPUState (normalizing only the RAM
+pointer) and 64 KiB of RAM after each tested entry. Inputs include matrix
+aliases, signed zero, NaNs, infinities, subnormals, raw float bit patterns,
+FP-disabled entry, reservation state, and boundary/MMIO addresses that must
+fall back. These are Mac-host comparisons against the extracted existing
+generated region, not an iPhone test or proof of a whole connected path.
+
+The mechanism preserves arithmetic and exception-helper code. Within the
+validated RAM-only region, no memory callback or journal can observe an
+intermediate FPRF value; arithmetic helpers read other FPSCR fields, not that
+classification field. Record the most recent successful FP result, then
+compute/commit its classification before every region exit. Keep exception
+flags, rounding, registers, memory writes and cycle charges unchanged. The
+fast entry rejects FP-disabled state, reservations, an active write journal
+and memory ranges outside the checked matrices/stack/constants.
+
+This is a **mechanism preflight**, not a decision to ship another isolated
+leaf. The inverse-transpose entry represented only about 4.3% of sampled
+dispatch time, and that share is inclusive. Its local gain cannot establish a
+substantial whole-game improvement. The next step is to extend and measure
+the mechanism across the connected joint-transform math path, including its
+trigonometric work, while preserving observation and exit boundaries.
+
+Private source snapshots, executable, exact logs and SHA-256 manifest are in
+`ref/revision-102/performance-loop/alias-preflight/`. The successful artifact
+is `inverse-deferred.c` with `deferred-float.c`; the expanded test result is
+`test-inverse-deferred-edge.log`. The goal remains incomplete until a useful
+connected-path implementation passes physical-iPhone validation.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -385,3 +385,27 @@ Original trig is restored. Device game data remains installed. Hardware
 retention remains open pending this candidate's capture and a valid comparison.
 Private scripts/logs are under `alias-preflight/build-scalar-family*`,
 `test-scalar-family-*.log`, and `scalar-candidate/`.
+
+
+### Build 16 not retained; native profiling connection fails
+
+Build 16 reached the same roster/stage, opening stage select one guest frame
+earlier. Against the cooled control its CPU means are 16.576, 21.206 and
+23.418 ms (+6.52%, +25.89%, +23.35%); FPS is 56.14, 45.15 and 40.90. Draws,
+primitives and guest cycles also differ, and thermal state changes from fair
+to serious. This does not establish an intrinsic regression or improvement,
+but it fails the retention gate. Do not ship either private math candidate.
+
+Both candidate captures are preserved. Build 16 was stopped and baseline-module
+build 15 restored, without launching another benchmark. No current private
+optimization is installed. The outstanding problem remains substantial
+sustained CPU/thermal performance, despite the isolated matrix improvement.
+
+A bounded native CPU Profiler attempt failed to find the PID that CoreDevice
+confirmed running. A second attempt by app name timed out waiting for the
+physical device to boot. Instruments lists that exact iPhone; get-task-allow
+is true, Developer Mode is enabled, and DDI services are available. Installed
+Xcode is 26.6 (17F113), device OS 26.6.1. These facts establish a profiler
+connection failure, not its root cause or a confirmed Xcode incompatibility.
+Do not repeat warm match comparisons as a substitute for native attribution.
+Private errors and device-state receipts are under `scalar-candidate/`.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -409,3 +409,19 @@ Xcode is 26.6 (17F113), device OS 26.6.1. These facts establish a profiler
 connection failure, not its root cause or a confirmed Xcode incompatibility.
 Do not repeat warm match comparisons as a substitute for native attribution.
 Private errors and device-state receipts are under `scalar-candidate/`.
+
+
+### Profiler connection diagnosis: physical reconnect requested
+
+The Instruments GUI opens but its device picker lists only the Mac and
+Additional Simulators, not either attached physical device. No recording was
+started. Scoped Instruments/DTServiceHub logs report `kAMDNotConnectedError`
+(0xe800000b), failure to start the device session, and an explicit instruction
+to reconnect the device. CoreDevice discovery and app installation still work;
+that does not imply the Instruments connection is healthy.
+
+The owner has been asked to unlock and physically reconnect the iPhone's USB
+cable. This is now the concrete external step for native profiling, not a claim
+that Xcode must be upgraded. The baseline-module build 15 remains installed and
+stopped. Native profiling is the current gate; neither experimental math module
+is retained, and the full performance goal is not achieved.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -195,3 +195,32 @@ Private source snapshots, executable, exact logs and SHA-256 manifest are in
 is `inverse-deferred.c` with `deferred-float.c`; the expanded test result is
 `test-inverse-deferred-edge.log`. The goal remains incomplete until a useful
 connected-path implementation passes physical-iPhone validation.
+
+
+## Integrated private math module
+
+The deferred-classification mechanism now also covers the connected sine,
+cosine and absolute-value region, retaining the generated arithmetic and
+call/cycle boundaries. The private module routes only guarded exact entries
+through the candidate and rejoins the original chunk return dispatcher.
+Unsupported states retain the original generated path. No production module
+or accepted main source has been replaced.
+
+The integrated Mac module passed 100,000 inverse-transpose and 10,000
+trigonometric comparisons against the original compiled module through the
+same module-dispatch interface. Comparisons cover complete CPUState and RAM,
+including edge floats, FP control bits, cycle exits and fallback conditions.
+The inverse microbenchmark measured 350–356 ns baseline versus 136–139 ns
+candidate across seven alternating pairs. This is local host timing, not an
+iPhone or whole-frame improvement. Earlier direct-wrapper timing is not a
+comparable integrated benchmark.
+
+Private reproducible integration/build scripts and logs are in
+`ref/revision-102/performance-loop/alias-preflight/`: `build-family.py`,
+`build-family-ios.py`, `test-family-inverse.log`, and `test-family-trig.log`.
+The physical iOS module built successfully. Private build 13 passed strict
+code-signature verification, was installed over the regular iPhone app and
+launched with profiling enabled. Its v1.00 module is byte-identical to build
+12; existing app data was retained. Physical correctness, sustained heavy-scene
+performance and whether the gain is worth shipping remain open. Installation
+and launch receipts are under `ref/revision-102/performance-loop/math-candidate/`.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -366,3 +366,22 @@ move in both directions. Reject the trig component. A revised private module
 is building with inverse plus the correctness-tested scalar matrix-add region,
 restoring the original trig chunk. No further phone build is installed yet;
 build 14 was stopped after saving its capture. Retention remains unproven.
+
+
+### Matrix-only build 16 launched
+
+The revised integrated module passed 100,000 inverse and 100,000 scaled-add
+comparisons, plus the 10,000-case original-trig comparison. Scaled-add checks
+include output MMIO/boundary fallback and partial output/input aliasing. Both
+matrix tests use the compiled module dispatcher on each side. Host timing is
+about 61% lower for inverse and 37–39% lower for scaled-add, not a whole-frame
+or device estimate.
+
+The physical module compiled/linked, private build 16 passed strict signature
+verification, and it was installed and launched with the fixed four-player
+route and capture enabled. The app executable is the existing route-enabled
+build; only the v1.02 module changes, and v1.00's module remains byte-identical.
+Original trig is restored. Device game data remains installed. Hardware
+retention remains open pending this candidate's capture and a valid comparison.
+Private scripts/logs are under `alias-preflight/build-scalar-family*`,
+`test-scalar-family-*.log`, and `scalar-candidate/`.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -330,3 +330,20 @@ process was terminated after capture, leaving the phone idle to cool. A cooled
 comparison is warranted by the unresolved thermal/workload confounds; repeated
 warm runs are not. Private analysis: `route-comparison1.json`, `compare-route.py`,
 and both route directories' `capture1-sha256.json` files.
+
+
+### Cooled control captured
+
+The baseline was confirmed stopped, then left idle for just over five minutes
+before relaunch. Its route again fixed the same roster at frame 2042 and opened
+stage selection at 2043. Initial telemetry reported serious, then fair, then
+serious again later in the run; idle duration alone is not a thermal-state
+measurement. CPU means for the three windows are 15.561, 16.844 and 18.985 ms;
+FPS from mean frame time is 58.53, 56.88 and 50.54. This shows the substantial
+thermal sensitivity of the baseline, not an optimization gain.
+
+Complete capture files and hashes are `route-control/*-cooled2.*` and
+`cooled2-sha256.json`. The baseline process was stopped at 10:33:47 UTC and
+candidate build 14 was reinstalled without launching it. The matching candidate
+cooldown is in progress. The goal remains incomplete and the experimental
+module remains outside main and any public release.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -1,0 +1,90 @@
+# Heavy-scene iPhone performance goal loop
+
+Started 2026-09-08. The owner accepts build 11 as the next baseline and authorizes
+merging it, then further focused optimization. This supersedes the prior
+preferred-revision loop for new work. Acceptance does not erase known slowdown
+or establish physical online-match success. No new public IPA is requested.
+
+## Outcome
+
+Prepare one worthwhile optimization for the physical iPhone's heavy scenes,
+with preserved gameplay and a repeatable measured benefit. Use the completed
+v1.02 decompilation to understand and specialize the existing translation;
+matching original code is not itself an optimized Apple-native port.
+
+The older v1.00 investigations remain in [the previous iPhone ledger](IPHONE-PERFORMANCE-GOAL-LOOP.md).
+
+## Current state
+
+- Accepted baseline merged in PR #4, main commit `5661889`.
+- Full repository checks passed before merge. Prior device installs and owner's
+  testing remain the acceptance evidence; no replacement IPA was published.
+- [Latest evidence](artifacts/2026-09-08/iphone-heavy-scene-performance.md):
+  verified v1.02 on iPhone build 11, 1×/4:3, samples at 9.9 then 34–43 FPS.
+- New goal is active. Current step: obtain useful attribution with the existing
+  profiler and inspect one connected function family for specialization.
+
+## Loop
+
+1. Reuse the existing frame-phase and sampled dispatch-time traces. Capture one
+   short heavy scene on the physical iPhone. Identify stage/fighters and pause
+   timing; use the exact v1.02 symbol map. Logging overhead is unmeasured, so
+   this identifies candidates rather than proving final uninstrumented speed.
+2. Select one substantial target: connected joint-transform/collision calls if
+   game CPU dominates; common precompiled vertex decoders if graphics CPU
+   dominates; shader warm-up only if measured compilation/fallback cost warrants
+   it. Read and preserve existing caching and validity guards.
+3. Implement the smallest useful specialization behind a reversible gate. Check
+   memory/state, floating-point edge cases, timing and fallback equivalence.
+   Avoid another standalone matrix leaf rewrite: prior projected gains were too
+   small. Do not substitute reduced game speed or skipped simulation work.
+4. Build a physical-iPhone candidate and compare the same scene at 1×/4:3 with
+   comparable temperature, including a warmed repeat and audio/frame tails.
+   Verify the benefit without tracing. Keep only a repeatable worthwhile gain.
+5. Record the result and stop that candidate if inconclusive. Choose another
+   only when evidence identifies a better target; no broad benchmark sweep.
+
+Preserve v1.00. Game-semantic changes require equivalence before online use;
+all future netplay acceptance is physical iPad–iPhone. No Simulator netplay or
+QuickTime recording. Keep game data, generated modules, captures and device
+identifiers private. Preserve the unrelated local images.
+
+## Minimal capture handoff
+
+The next diagnostic build accepts the developer launch environment variable
+`MELEEPAD_PERFORMANCE_CAPTURE=1`. It resolves the existing profiler's outputs
+inside the app's Logs directory; no product setting or persistent preference
+is added. Ordinary launches retain existing logging.
+
+Launch with `devicectl device process launch --device <physical-iPhone>
+--terminate-existing --environment-variables '{"MELEEPAD_PERFORMANCE_CAPTURE":"1"}'
+<installed-bundle-id>`. Confirm the regular app identity before launch.
+
+Reproduce the heavy scene for approximately 30–60 seconds, then use the app's
+normal stop/return flow to flush buffered samples. Retrieve
+`Library/Application Support/MeleePad/Logs/performance-phase.csv` and
+`performance-dispatch.csv` together with `runtime.log`. Do not force-terminate
+before retrieval: the final dispatch buffer flushes on normal runtime shutdown.
+Each profiler session overwrites these CSVs, so copy them before another run.
+Relaunch normally afterward to disable tracing. Captures are private and not
+part of the normal shared problem report.
+
+Use `scripts/analyze-dispatch-time-samples.py` for the selected emulated-frame
+window, then `scripts/symbolize-melee.py --dol <verified-v1.02-main.dol>` for
+ranked PCs. Dispatch frequency alone is not execution-time attribution.
+A timed dispatch can include continuation work after its named entry; its
+inclusive time must not be treated as the exclusive cost of a leaf. The prior
+iPhone I14 matrix experiment demonstrated this failure directly. Use the
+existing burst trace only if call-context ambiguity prevents choosing a
+composed path; do not add another generic profiler.
+
+## Iteration ledger
+
+- 2026-09-08: merged the accepted baseline and reused the existing profiler via
+  one developer launch flag. The physical-iOS Release build passed; device attribution
+  remains pending; no new speedup is claimed.
+
+- Source follow-up: the previous iPhone I14/I15 ledger already rejects GX
+  matrix leaf specialization and establishes inclusive-time bias. Preserve
+  that result. Decomp joint/collision inspection informs composed paths, not
+  a renewed claim that leaf SIMD is a sufficient fix.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -224,3 +224,30 @@ launched with profiling enabled. Its v1.00 module is byte-identical to build
 12; existing app data was retained. Physical correctness, sustained heavy-scene
 performance and whether the gain is worth shipping remain open. Installation
 and launch receipts are under `ref/revision-102/performance-loop/math-candidate/`.
+
+
+### First physical candidate samples: useful local gain, no whole-frame claim
+
+Build 13's fresh runtime log confirms revision 2 and its new module size.
+It reached heavy graphics automatically after the light opening scene; the
+owner has not confirmed a controlled multi-fighter match. The two 600-frame
+windows at emulated frames 7000 and 8800 are complete in both CSV sets.
+However, neither window has a single frame with matching draw and primitive
+counts across baseline and candidate. Workloads differ substantially.
+Candidate CPU-thread means are 20.842 and 15.108 ms versus baseline 20.273
+and 23.586 ms. These differences cannot establish a whole-frame speedup.
+
+Across those windows, mean corrected inclusive time per sampled inverse entry
+falls from 777.51 ns (262 samples) to 322.85 ns (292 samples). Cosine remains
+316.85 versus 319.04 ns; sine remains 342.32 versus 337.59 ns. This supports
+an on-device benefit for the inverse mechanism, but not the added trig region
+or a substantial application-wide improvement. Different input distributions
+and thermal scheduling still limit the per-entry comparison.
+
+The integrated host comparisons also passed all four host rounding modes:
+400,000 inverse and 40,000 trig entries. Logs are private. The next source
+candidate is deferred classification across the paired-single matrix region;
+its helpers repeatedly classify results in `cpu_interpreter_float.c`. This
+is distinct from the previously rejected standalone matrix leaf replacement.
+Owner-driven heavy-match capture remains requested; build 13's profiler is
+currently active. No release or merge of the experiment is justified yet.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -425,3 +425,17 @@ cable. This is now the concrete external step for native profiling, not a claim
 that Xcode must be upgraded. The baseline-module build 15 remains installed and
 stopped. Native profiling is the current gate; neither experimental math module
 is retained, and the full performance goal is not achieved.
+
+
+### Blocked audit
+
+The native-profiler connection failure has persisted across three consecutive
+goal turns: CLI attachment failed, GUI/log diagnosis confirmed the missing
+physical device and kAMDNotConnectedError, and a fresh GUI recheck still lists
+only the Mac and Additional Simulators. The requested physical unlock/USB
+reconnect has not been confirmed. Further speculative optimizations or repeated
+warm timings would not establish the required substantial physical improvement.
+The goal is blocked on restoring the Instruments device session, not complete.
+Resume by verifying the iPhone appears in Instruments, then collect a bounded
+native CPU profile of the fixed heavy match before selecting another change.
+The original module remains restored; no candidate is approved for release.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -251,3 +251,26 @@ its helpers repeatedly classify results in `cpu_interpreter_float.c`. This
 is distinct from the previously rejected standalone matrix leaf replacement.
 Owner-driven heavy-match capture remains requested; build 13's profiler is
 currently active. No release or merge of the experiment is justified yet.
+
+
+### Follow-up screen and bounded capture closure
+
+Inspection rejected the proposed paired-single extension: the generated
+PSMTXConcat arithmetic is already inline and does not call the repeated FPRF
+classification helpers. Extending that mechanism there would have no basis.
+The scalar HSD_MtxScaledAdd region does still use twelve scalar multiply-add
+helpers. A guarded private prototype passed 100,000 whole-state/RAM entry
+comparisons against the compiled baseline. Its direct-wrapper host timing
+cannot yet support an integrated or physical gain; no new device build was
+made from this extension.
+
+The build 13 capture was saved under `math-candidate/*-bounded-final.*` with
+SHA-256 hashes, then profiling was disabled by normal relaunch. Fresh runtime
+session 2026-09-08T10:11:07.899Z confirms build 13 without capture activation.
+The earlier statement that its profiler remains active is superseded.
+
+Next gate is a reproducible physical multi-fighter match, requested from the
+owner but not yet confirmed. Automatic scene workloads differ, so further
+small host optimizations cannot settle acceptance. Hold integration/release
+of the candidate until that hardware comparison can establish whether it is
+worth retaining. Existing stable main and device game data remain preserved.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -303,3 +303,30 @@ the stage selector accepted forced stage 0x13 (Big Blue). Both seed boundary
 writes succeeded. This removes the immediate need for owner-operated setup;
 the physical comparison can proceed autonomously. Whole-frame improvement
 remains unverified until both runs are captured and compared.
+
+
+### First fixed four-player pair: inconclusive under thermal pressure
+
+Both builds reached the checked 10040506 roster and Big Blue. Build 14 uses
+the candidate module; build 15 uses the original module. Both use the same
+app executable before its signature blob, original 4:3, 1x rendering, and
+identical profiling flags. Complete phase and dispatch windows were saved
+privately with hashes. Both runs report serious thermal state.
+
+| Emulated frames | Candidate CPU ms | Control CPU ms | Candidate FPS | Control FPS |
+| --- | ---: | ---: | ---: | ---: |
+| 3000–3599 | 17.048 | 15.671 | 54.49 | 58.05 |
+| 4200–4799 | 19.786 | 16.970 | 48.39 | 55.74 |
+| 5400–5999 | 20.919 | 26.618 | 45.83 | 36.05 |
+
+FPS here is 1000 divided by mean recorded frame time. Candidate draw counts
+are +5.64%, +2.67%, and -1.37%; primitives are +1.93%, +1.59%, and -3.83%.
+This is not equal-work evidence or a consistent improvement. Thermal pressure
+also changes within the broad serious category. Do not retain the candidate
+from this pair or claim the heavy-scene slowdown is fixed.
+
+The original module is currently installed in private build 15. The benchmark
+process was terminated after capture, leaving the phone idle to cool. A cooled
+comparison is warranted by the unresolved thermal/workload confounds; repeated
+warm runs are not. Private analysis: `route-comparison1.json`, `compare-route.py`,
+and both route directories' `capture1-sha256.json` files.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -21,10 +21,9 @@ The older v1.00 investigations remain in [the previous iPhone ledger](IPHONE-PER
   testing remain the acceptance evidence; no replacement IPA was published.
 - [Latest evidence](artifacts/2026-09-08/iphone-heavy-scene-performance.md):
   verified v1.02 on iPhone build 11, 1×/4:3, samples at 9.9 then 34–43 FPS.
-- Current step: physical build 12 is installed and running with profiling.
-  Initial CSV retrieval confirms 2,310 complete frame rows and 32,768 timed
-  dispatch rows; these initial records do not yet include a heavy scene.
-  Wait for the short gameplay reproduction before selecting an optimization.
+- Current step: heavy-scene capture is complete and the iPhone has been
+  relaunched normally with profiling off. The selected optimization lane is
+  composed matrix processing; see the measured attribution below.
 
 ## Loop
 
@@ -104,3 +103,49 @@ composed path; do not add another generic profiler.
   verified revision 2, and profiler activation. Both CSVs were retrieved and
   parsed successfully. Installation preserves game data. Heavy-scene
   reproduction is pending; initial menu samples are not optimization evidence.
+
+## First completed v1.02 physical capture
+
+The previous execution turn made concrete progress by installing and running
+build 12. This continuation retrieved heavy-frame data, checked complete
+window coverage, and symbolized PCs against the hash-verified v1.02 DOL.
+
+| Emulated frames | Rows | Mean frame | CPU-thread mean | Metal pipeline creation/frame | Timed dispatch samples |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 7000–7599 | 600 | 21.333 ms | 20.273 ms | 0.0035 ms | 24,991 |
+| 8800–9399 | 600 | 24.548 ms | 23.586 ms | 0.021 ms | 21,227 |
+
+Both windows are inside the flushed dispatch trace. An initial live copy
+ended at frame 9023 and therefore could not support the entire second window;
+that incomplete analysis was replaced with the final capture. Raw logs and
+hashes remain private under `ref/revision-102/performance-loop/`.
+
+The logged settings are 1× / original 4:3, with serious thermal state during
+the slowdown. These are instrumented observations, not an uninstrumented
+performance baseline. Stage/fighter identity has not been independently
+confirmed; heavy graphics and CPU slowdown are observed directly.
+
+Across these two windows, the leading named entries by mean sampled dispatch
+time are PSMTXConcat (6.09%), GXLoadPosMtxImm (5.83%),
+HSD_MtxInverseTranspose (4.30%), GXLoadNrmMtxImm (3.41%), sinf (3.25%) and
+cosf (3.00%). HSD_MtxScaledAdd contributes 1.79%. These are percentages of
+corrected sampled dispatch time, not exclusive leaf time or whole-frame
+savings. Estimated dispatch coverage is only 79.2% / 68.9% of CPU-thread time.
+
+Decision: postpone shader warm-up and vertex-loader changes as the first
+experiment. CPU-thread cost nearly fills the observed frame budget, and
+recorded pipeline-creation cost is small in these sustained intervals. This
+does not measure all GPU work or explain every first-use hitch.
+
+The next code experiment should cover a connected matrix path, not repeat the
+rejected standalone GX leaf. The pinned `SetupEnvelopeModelMtx` implementation
+(`src/sysdolphin/baselib/pobj.c:1125`) provides one concrete composition of
+joint preparation, concat, weighted accumulation, inverse-transpose and GX
+upload. Source structure makes this a candidate, not proof that all sampled
+matrix calls originate there. Any private preflight must preserve intermediate
+guest state/memory, cycle exits, FP rounding and code-validity guards; local
+math timing alone cannot qualify it for a claimed device improvement.
+
+The final CSVs were copied before restarting the regular app without capture
+environment variables. The unflushed trailing dispatch buffer is deliberately
+not part of the evidence. No new optimization has been installed.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -21,8 +21,10 @@ The older v1.00 investigations remain in [the previous iPhone ledger](IPHONE-PER
   testing remain the acceptance evidence; no replacement IPA was published.
 - [Latest evidence](artifacts/2026-09-08/iphone-heavy-scene-performance.md):
   verified v1.02 on iPhone build 11, 1×/4:3, samples at 9.9 then 34–43 FPS.
-- New goal is active. Current step: obtain useful attribution with the existing
-  profiler and inspect one connected function family for specialization.
+- Current step: physical build 12 is installed and running with profiling.
+  Initial CSV retrieval confirms 2,310 complete frame rows and 32,768 timed
+  dispatch rows; these initial records do not yet include a heavy scene.
+  Wait for the short gameplay reproduction before selecting an optimization.
 
 ## Loop
 
@@ -95,3 +97,10 @@ composed path; do not add another generic profiler.
   It is not installed or published. The device still has accepted build 11.
   Diagnostics/privacy tests and dispatch-time analyzer tests pass. Next step
   is the short physical heavy-scene capture, then one selected optimization.
+
+- Execution correction: the previous handoff ended without running the next
+  step. Build 12 has now actually been installed in the regular iPhone app
+  container and launched with capture enabled. Runtime log confirms build 12,
+  verified revision 2, and profiler activation. Both CSVs were retrieved and
+  parsed successfully. Installation preserves game data. Heavy-scene
+  reproduction is pending; initial menu samples are not optimization evidence.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -499,3 +499,66 @@ recordings completed normally. The app was stopped after collection to end the
 benchmark and allow cooling; build 15 and game data are unchanged. No Simulator,
 QuickTime recording, release upload, or netplay test was used. The physical
 connection blocker is resolved; the performance objective is still unfinished.
+
+
+### Build 17 — separate normal CPU execution from diagnostics
+
+Native instruction inspection mapped the matrix-write hot offsets back to
+`WriteMTXPS4x3`/the previously rejected GX family. Another replacement of that
+leaf would repeat the closed experiment. The fresh control instead confirms
+that the host `StaticRecompCore::Run` loop itself consumes about 9% of CPU-thread
+samples even with phase/dispatch capture off.
+
+Patch 0056 compiles two versions of the same loop. `Run()` selects the diagnostic
+version when phase timing, lockstep, dispatch sampling/timing/burst logging, or
+freeze tracing is enabled; ordinary execution selects the version in which
+those branches and bookkeeping compile away. The execution body from module and
+idle setup onward is byte-identical source. Cycle charges, timebase updates,
+interrupt/exception delivery, fallback, SMC eligibility, stop/pause handling,
+and canonical netplay-boundary capture remain in both paths. Neither game
+module changes, and no game-data changes are required.
+
+An exact physical-iOS compiler screen reduced the normal function from 1,491 to
+841 ARM64 instructions and its stack frame from 544 to 192 bytes. Diagnostic
+call sites disappear only from the normal specialization. These are code-size
+and code-generation facts, not FPS claims.
+
+A fresh physical control (build 15) and candidate (build 17) both ran the fixed
+four-fighter Big Blue route with capture disabled, v1.02, original modules,
+1x EFB and 4:3. The candidate started after five minutes stopped for cooling;
+both native trace intervals report nominal thermals. Each 25-second Time
+Profiler recording began approximately 74 seconds after launch. The route's
+wall-clock fallback reached the fixed roster/stage in both runs, but subsequent
+AI/workload progression is not frame-exact.
+
+| Native running samples | Control | Build 17 |
+| --- | ---: | ---: |
+| CPU-thread total | 18,515 ms | 18,075 ms |
+| Normal execution-loop self | 1,683 ms | 980 ms |
+| Loop self / CPU-thread total | 9.09% | 5.42% |
+| Unchanged game module self, including helpers | 12,953 ms | 13,131 ms |
+| Video-thread total | 11,774 ms | 12,183 ms |
+
+The targeted loop drops 41.8% in sampled self time while module samples differ
+by +1.37%. Checking direct compiler-outlined callees found no shifted sample
+bucket explaining the loop reduction. Total CPU samples are 2.38% lower in
+this interval. This supports retaining a modest host-loop optimization on the
+working branch; it does not establish a precise whole-game speedup or sustained
+60 FPS. Later runtime FPS readings remain mixed and both runs slow as workload
+and thermal state change. Do not advertise the iPhone slowdown as fixed.
+
+The core and physical iOS Release build pass. Existing benchmark route,
+diagnostic/privacy, idle-policy, lightweight-frame recorder, and dispatch-time
+checks pass. The patch passes `git apply --check` and `--recount` against the
+saved baseline and reproduces the built source exactly. Private evidence and
+signed build-17 manifest are in
+`ref/revision-102/performance-loop/loop-specialization/`. Instruments sample
+exports intermittently crashed; exporting the complete candidate trace to
+stdout succeeded with exit 0, and the complete XML was parsed for the table.
+No online acceptance, public IPA, or release/main merge is claimed.
+
+A separate physical diagnostic-path smoke test on build 17 enabled capture and
+produced 1,739 data rows in a fresh phase CSV. The runtime reached normal game
+execution. Capture and the benchmark route were then disabled by normal
+relaunch; build 17 remains installed for owner testing. This is not a physical
+lockstep/netplay acceptance result.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -274,3 +274,32 @@ owner but not yet confirmed. Automatic scene workloads differ, so further
 small host optimizations cannot settle acceptance. Hold integration/release
 of the candidate until that hardware comparison can establish whether it is
 worth retaining. Existing stable main and device game data remain preserved.
+
+
+### Automated v1.02 comparison route
+
+The owner-driven gate above is not the only available next action. Inspection
+found the existing four-player route, whose guest readers/writers explicitly
+rejected revision 2. Its v1.02 address selection is now implemented using the
+pinned decomp's symbols and struct layouts: state_machine 80479D30, P1 cursor
+pointer 804A0BC0, CSSData pointer 804D6CB0, SSSData pointer 804D6C90, and HSD
+seed/seed_ptr 804D5F90/804D5F94. Pointer/layout checks and v1.00 addresses remain.
+The changes are restricted to the existing developer benchmark launch mode.
+
+Route tests and the physical-iOS Release build passed. Private build 14 is
+installed and running `versus-four-big-blue-v1` with capture enabled, using
+build 13's optimized modules. A control build 15 is prepared with the same
+executable bytes before the code-signature blob and the baseline v1.02 module.
+Signature differences reflect the different build-number seal. The route's
+actual fixed-roster/stage acceptance is not yet established; opening menu
+input is confirmed by a fresh runtime log. This route is a fixed workload
+setup, not a claim of frame-exact deterministic replay.
+
+
+Build 14 route progression is now verified in `route-candidate/runtime-second.log`:
+normal input enabled the three CPU doors; at emulated frame 2042 the checked
+roster write set 10040506, frame 2043 confirmed slot types 00/01/01/01, and
+the stage selector accepted forced stage 0x13 (Big Blue). Both seed boundary
+writes succeeded. This removes the immediate need for owner-operated setup;
+the physical comparison can proceed autonomously. Whole-frame improvement
+remains unverified until both runs are captured and compared.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -88,3 +88,10 @@ composed path; do not add another generic profiler.
   matrix leaf specialization and establishes inclusive-time bias. Preserve
   that result. Decomp joint/collision inspection informs composed paths, not
   a renewed claim that leaf SIMD is a sufficient fix.
+
+- Handoff: private diagnostic build 12 is prepared from the accepted regular
+  app with the new host executable. Its existing game modules are unchanged;
+  signing with the baseline certificate and strict bundle verification pass.
+  It is not installed or published. The device still has accepted build 11.
+  Diagnostics/privacy tests and dispatch-time analyzer tests pass. Next step
+  is the short physical heavy-scene capture, then one selected optimization.

--- a/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/IPHONE-102-PERFORMANCE-GOAL-LOOP.md
@@ -439,3 +439,63 @@ The goal is blocked on restoring the Instruments device session, not complete.
 Resume by verifying the iPhone appears in Instruments, then collect a bounded
 native CPU profile of the fixed heavy match before selecting another change.
 The original module remains restored; no candidate is approved for release.
+
+
+### Reconnected iPhone: native heavy-match attribution completed
+
+After the owner reconnected the iPhone, Time Profiler successfully attached.
+A 15-second connection check contained startup samples only; it is not gameplay
+evidence. Two subsequent 25-second recordings captured the fixed four-fighter
+Big Blue route on private build 15, verified USA v1.02, original module,
+1x rendering and 4:3. No new module was installed. The second recording disabled
+internal phase and dispatch timing (`MELEEPAD_PERFORMANCE_CAPTURE=0`). Its route
+used the documented wall-clock fallback and reached the same fixed roster and
+stage; it is not a frame-exact A/B comparison.
+
+Native running-sample attribution with internal capture disabled:
+
+| Measurement | Result |
+| --- | ---: |
+| CPU-thread sampled time | 25,079 ms |
+| Video-thread sampled time | 18,682 ms |
+| Generated guest-body leaf samples / CPU thread | 46.29% |
+| Module helper/dispatcher leaf samples / CPU thread | 24.10% |
+| Core/system leaf samples / CPU thread | 29.58% |
+| Clock leaf samples / CPU thread | 0.04% |
+| `ppc_fmadd_op` self / CPU thread | 5.40% |
+| `ppc_fp_available` self / CPU thread | 4.49% |
+| `RunGpuLoop` plus `SetCPStatusFromGPU` self / video thread | 46.91% |
+
+These are statistical native CPU samples, not GPU execution times or predicted
+FPS gains. The large video-loop share includes polling, but the complete loop
+must not be classified as removable idle work. Earlier I7 already rejected
+immediate sleeping and a 1,024-spin threshold after context switches increased.
+This trace does not justify repeating either rejected change.
+
+Internal capture substantially perturbs the CPU profile: clock leaf samples
+were 7.35% with it enabled, versus 0.04% disabled. The source calls the thread
+CPU clock at each timed CPU slice. This is diagnostic overhead, not a newly
+removed shipping cost. Future native attribution should keep internal capture
+off; use phase/dispatch captures separately when frame alignment is required.
+The capture-disabled run still slowed: runtime logs reported 55.6 and 47.5 FPS
+in later intervals with CPU-thread utilization near 99% and thermal state fair.
+Thus internal timing does not explain away the owner's slowdown.
+
+The most useful next optimization hypothesis remains a bounded native region
+that reduces repeated guest-state/helper round trips across the matrix/joint
+path. Native samples identify matrix chunk `80341940` as the largest caller of
+paired loads and FP availability checks; inverse/scalar chunk `80379940`
+concentrates multiply/add helpers. These chunk names span many guest functions;
+map sampled instruction offsets to exact decompilation functions before choosing
+another entry. A tiny leaf optimization cannot recover the entire inclusive
+entry share. Prior inverse/trig/scalar candidates remain rejected; no new
+whole-game performance improvement is claimed.
+
+Private evidence is under `ref/revision-102/performance-loop/scalar-candidate/`:
+`reconnected-heavy.trace`, `reconnected-clean.trace`, their exported samples,
+summary/family reports, and the matching fresh runtime/phase/dispatch pulls.
+The first clean-trace sample export crashed; a fresh export succeeded. Both
+recordings completed normally. The app was stopped after collection to end the
+benchmark and allow cooling; build 15 and game data are unchanged. No Simulator,
+QuickTime recording, release upload, or netplay test was used. The physical
+connection blocker is resolved; the performance objective is still unfinished.

--- a/docs/REVISION-102-GOAL-LOOP.md
+++ b/docs/REVISION-102-GOAL-LOOP.md
@@ -6,6 +6,14 @@ decompilation, and pursuing measured improvements. This loop governs that new
 work; historical performance gates remain evidence requirements, not a ban on
 implementing the newly requested revision support.
 
+## Accepted baseline and successor goal
+
+On 2026-09-08 the owner accepted build 11 as the next baseline and authorized
+merge. PR #4 merged as `5661889`; no new public IPA was requested. The revision
+support work is complete for this accepted scope. Known heavy-scene slowdown
+and physical online-match acceptance remain documented debt. Further work is
+governed by [the new iPhone v1.02 performance loop](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
+
 ## Product contract
 
 - Detect the actual imported revision; never infer it from a filename.

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -9,6 +9,27 @@ Current active work: [v1.02 iPhone performance goal](IPHONE-102-PERFORMANCE-GOAL
 The owner accepted build 11 as the merged baseline; performance and physical
 netplay limitations below remain open.
 
+## Current performance investigation — private builds 12–15
+
+A source-guided deferred floating-point classification prototype reduces sampled
+inverse-matrix entry time on the physical iPhone, but no substantial whole-game
+improvement is established. Sine/cosine regressed in the cooled capture and are being removed. The
+prototype remains private and has not replaced the accepted main module.
+
+The existing physical four-fighter benchmark now supports v1.02 using verified
+decompilation symbols and layouts. It reaches a fixed roster on Big Blue through
+normal menu input plus guarded benchmark-only seed/roster/stage writes. The first
+candidate/control pair varied in both directions under serious thermal pressure.
+A cooled pair favors the candidate by about 4% CPU time in closely matched
+workloads, but different starting thermal states limit attribution. A revised
+matrix-only candidate is building. Treat this as unresolved sustained CPU/thermal performance,
+not a version-import or resolution-setting fix.
+
+Next decision: finish the cooled comparison and retain only a demonstrated
+whole-game benefit. Do not ship the prototype, extrapolate its leaf timing to
+FPS, or keep running warm comparisons to seek a favorable number. See the
+[full evidence and current device state](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
+
 ## Build 9 handoff — v1.02, performance, and hardware netplay
 
 USA v1.02 is now preferred for new development setups; v1.00 remains supported

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -5,7 +5,7 @@ Last updated: 2026-09-08
 This is the short, ranked engineering queue behind the active goal loop. It is
 not a substitute for `GOAL-LOOP.md` or evidence in `docs/artifacts/`.
 
-Current active work: [v1.02 iPhone performance goal](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
+Current work, blocked on the Instruments device connection: [v1.02 iPhone performance goal](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
 The owner accepted build 11 as the merged baseline; performance and physical
 netplay limitations below remain open.
 

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -27,7 +27,9 @@ Next gate is native CPU attribution, not more warm match repetitions. The CLI
 CPU Profiler cannot attach by PID or app name although CoreDevice sees the app,
 Developer Mode/DDI are available, and the debugging entitlement is enabled.
 Xcode 26.6 versus device OS 26.6.1 does not itself prove incompatibility; the
-profiler connection failure needs diagnosis. See the [full evidence and current
+GUI also omits the physical device; Instruments logs `kAMDNotConnectedError`
+and requests reconnecting it. The owner has been asked to unlock/reconnect the
+iPhone USB cable. See the [full evidence and current
 device state](IPHONE-102-PERFORMANCE-GOAL-LOOP.md). No experimental module has
 been merged or published, and substantial performance improvement remains open.
 

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -6,12 +6,12 @@ This is the short, ranked engineering queue behind the active goal loop. It is
 not a substitute for `GOAL-LOOP.md` or evidence in `docs/artifacts/`.
 
 Current work, native hardware profiling resumed: [v1.02 iPhone performance goal](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
-The owner accepted build 11 as the merged baseline; performance and physical
-netplay limitations below remain open.
+The owner requested merging the build-17 increment after physical gameplay.
+Sustained performance and physical netplay limitations remain open.
 
 ## Current performance investigation — private build 17
 
-Build 17 retains a modest host-loop optimization on the working branch:
+Build 17 adds a modest host-loop optimization:
 normal execution compiles out disabled diagnostic branches, while timing,
 lockstep, and diagnostic runs use the same fully instrumented loop. A physical
 25-second four-fighter comparison reduces loop self samples from 1,683 to
@@ -19,11 +19,17 @@ lockstep, and diagnostic runs use the same fully instrumented loop. A physical
 modules. This is a targeted improvement, not a precise FPS gain or a fix for
 sustained heavy-match slowdowns. Patch 0056 makes the change reproducible.
 
+The owner's latest gameplay logs confirm 41–45 FPS slowdown samples with
+serious thermal pressure and CPU-thread utilization of 86–93%. The owner finds
+it improved but still imperfect. Next logging work is frame-time p95/max,
+missed-frame counts and audio-underrun deltas at existing frame boundaries;
+avoid always-on per-dispatch timing. See the [owner-run assessment](artifacts/2026-09-08/build17-owner-gameplay.md).
+
 Neither tested math candidate is retained. Deferred floating-point classification
 substantially reduces isolated inverse-matrix time, but physical four-fighter
 comparisons do not establish a consistent whole-game improvement. Trig changes
 regressed; removing them and adding scalar matrix-add still failed the hardware
-retention gate. The original module is restored in private build 15.
+retention gate. The original module remains unchanged in private build 17.
 
 The physical four-fighter route now supports v1.02 using verified decompilation
 symbols and layouts. It reaches a fixed roster on Big Blue. Captures show strong

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -5,6 +5,10 @@ Last updated: 2026-09-08
 This is the short, ranked engineering queue behind the active goal loop. It is
 not a substitute for `GOAL-LOOP.md` or evidence in `docs/artifacts/`.
 
+Current active work: [v1.02 iPhone performance goal](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
+The owner accepted build 11 as the merged baseline; performance and physical
+netplay limitations below remain open.
+
 ## Build 9 handoff — v1.02, performance, and hardware netplay
 
 USA v1.02 is now preferred for new development setups; v1.00 remains supported

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -9,7 +9,15 @@ Current work, native hardware profiling resumed: [v1.02 iPhone performance goal]
 The owner accepted build 11 as the merged baseline; performance and physical
 netplay limitations below remain open.
 
-## Current performance investigation — private builds 12–16
+## Current performance investigation — private build 17
+
+Build 17 retains a modest host-loop optimization on the working branch:
+normal execution compiles out disabled diagnostic branches, while timing,
+lockstep, and diagnostic runs use the same fully instrumented loop. A physical
+25-second four-fighter comparison reduces loop self samples from 1,683 to
+980 ms (41.8%); total CPU-thread samples are 2.38% lower, with unchanged game
+modules. This is a targeted improvement, not a precise FPS gain or a fix for
+sustained heavy-match slowdowns. Patch 0056 makes the change reproducible.
 
 Neither tested math candidate is retained. Deferred floating-point classification
 substantially reduces isolated inverse-matrix time, but physical four-fighter
@@ -36,8 +44,8 @@ profiling. The capture-disabled run still slowed to 47.5 FPS in one later
 interval, so logging is not the whole issue. Next source gate: map matrix/joint
 native sample offsets to exact decompilation functions before selecting a
 bounded region optimization. See the [full evidence and current device
-state](IPHONE-102-PERFORMANCE-GOAL-LOOP.md). Build 15 was stopped after collection;
-no candidate was installed or retained and no new FPS gain is established.
+state](IPHONE-102-PERFORMANCE-GOAL-LOOP.md). That attribution led to the build-17 host-loop specialization above.
+No new sustained FPS claim or physical online acceptance is established.
 
 ## Build 9 handoff — v1.02, performance, and hardware netplay
 

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -5,7 +5,7 @@ Last updated: 2026-09-08
 This is the short, ranked engineering queue behind the active goal loop. It is
 not a substitute for `GOAL-LOOP.md` or evidence in `docs/artifacts/`.
 
-Current work, blocked on the Instruments device connection: [v1.02 iPhone performance goal](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
+Current work, native hardware profiling resumed: [v1.02 iPhone performance goal](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
 The owner accepted build 11 as the merged baseline; performance and physical
 netplay limitations below remain open.
 
@@ -23,15 +23,21 @@ thermal sensitivity: a cooled baseline begins near 60 FPS and slows as it warms.
 One cooled pair favored a candidate by about 4% CPU time, but differing starting
 thermal states and subsequent contrary results prevent retaining that claim.
 
-Next gate is native CPU attribution, not more warm match repetitions. The CLI
-CPU Profiler cannot attach by PID or app name although CoreDevice sees the app,
-Developer Mode/DDI are available, and the debugging entitlement is enabled.
-Xcode 26.6 versus device OS 26.6.1 does not itself prove incompatibility; the
-GUI also omits the physical device; Instruments logs `kAMDNotConnectedError`
-and requests reconnecting it. The owner has been asked to unlock/reconnect the
-iPhone USB cable. See the [full evidence and current
-device state](IPHONE-102-PERFORMANCE-GOAL-LOOP.md). No experimental module has
-been merged or published, and substantial performance improvement remains open.
+The owner reconnected the iPhone and two 25-second native Time Profiler
+captures of the four-fighter route succeeded. With internal capture disabled,
+CPU leaf samples split into 46.29% generated game bodies, 24.10% module helpers
+and dispatch, and 29.58% core/system. The video worker spends substantial time
+in FIFO/status polling; prior sleep-threshold experiments already regressed or
+failed to exceed noise and should not be repeated without a different mechanism.
+
+Internal diagnostic clock work accounts for 7.35% of CPU samples when capture
+is enabled, versus 0.04% disabled. Keep internal capture off during native
+profiling. The capture-disabled run still slowed to 47.5 FPS in one later
+interval, so logging is not the whole issue. Next source gate: map matrix/joint
+native sample offsets to exact decompilation functions before selecting a
+bounded region optimization. See the [full evidence and current device
+state](IPHONE-102-PERFORMANCE-GOAL-LOOP.md). Build 15 was stopped after collection;
+no candidate was installed or retained and no new FPS gain is established.
 
 ## Build 9 handoff — v1.02, performance, and hardware netplay
 

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -9,26 +9,27 @@ Current active work: [v1.02 iPhone performance goal](IPHONE-102-PERFORMANCE-GOAL
 The owner accepted build 11 as the merged baseline; performance and physical
 netplay limitations below remain open.
 
-## Current performance investigation — private builds 12–15
+## Current performance investigation — private builds 12–16
 
-A source-guided deferred floating-point classification prototype reduces sampled
-inverse-matrix entry time on the physical iPhone, but no substantial whole-game
-improvement is established. Sine/cosine regressed in the cooled capture and are being removed. The
-prototype remains private and has not replaced the accepted main module.
+Neither tested math candidate is retained. Deferred floating-point classification
+substantially reduces isolated inverse-matrix time, but physical four-fighter
+comparisons do not establish a consistent whole-game improvement. Trig changes
+regressed; removing them and adding scalar matrix-add still failed the hardware
+retention gate. The original module is restored in private build 15.
 
-The existing physical four-fighter benchmark now supports v1.02 using verified
-decompilation symbols and layouts. It reaches a fixed roster on Big Blue through
-normal menu input plus guarded benchmark-only seed/roster/stage writes. The first
-candidate/control pair varied in both directions under serious thermal pressure.
-A cooled pair favors the candidate by about 4% CPU time in closely matched
-workloads, but different starting thermal states limit attribution. A revised
-matrix-only candidate is building. Treat this as unresolved sustained CPU/thermal performance,
-not a version-import or resolution-setting fix.
+The physical four-fighter route now supports v1.02 using verified decompilation
+symbols and layouts. It reaches a fixed roster on Big Blue. Captures show strong
+thermal sensitivity: a cooled baseline begins near 60 FPS and slows as it warms.
+One cooled pair favored a candidate by about 4% CPU time, but differing starting
+thermal states and subsequent contrary results prevent retaining that claim.
 
-Next decision: finish the cooled comparison and retain only a demonstrated
-whole-game benefit. Do not ship the prototype, extrapolate its leaf timing to
-FPS, or keep running warm comparisons to seek a favorable number. See the
-[full evidence and current device state](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
+Next gate is native CPU attribution, not more warm match repetitions. The CLI
+CPU Profiler cannot attach by PID or app name although CoreDevice sees the app,
+Developer Mode/DDI are available, and the debugging entitlement is enabled.
+Xcode 26.6 versus device OS 26.6.1 does not itself prove incompatibility; the
+profiler connection failure needs diagnosis. See the [full evidence and current
+device state](IPHONE-102-PERFORMANCE-GOAL-LOOP.md). No experimental module has
+been merged or published, and substantial performance improvement remains open.
 
 ## Build 9 handoff — v1.02, performance, and hardware netplay
 

--- a/docs/artifacts/2026-09-08/build17-owner-gameplay.md
+++ b/docs/artifacts/2026-09-08/build17-owner-gameplay.md
@@ -1,0 +1,51 @@
+# Build 17 owner gameplay and merge assessment
+
+The owner tested the installed physical iPhone build on 2026-09-08 and reported
+that it felt faster, including with four players, but still slowed down. This is
+qualitative improvement feedback, not a stable-60-FPS acceptance claim.
+
+A read-only app-container pull preserved the running game. The session starts
+at 12:05:16 UTC and identifies build 17, verified USA revision 2 (v1.02), the
+original 81,964,624-byte module, 1x EFB 640x528 and original 4:3. Internal
+performance capture and the benchmark route are absent from the session.
+
+The last 60 performance summaries in the pull all report iOS thermal state
+`serious`; eight report under 55 FPS. Two particularly relevant samples:
+
+| UTC | FPS | CPU thread utilization | Video thread utilization | Audio underruns, cumulative |
+| --- | ---: | ---: | ---: | ---: |
+| 12:27:38 | 59.9 | 57.6% | 26.3% | 778 |
+| 12:27:48 | 41.4 | 92.9% | 49.8% | 804 |
+| 12:27:58 | 44.9 | 85.8% | 56.0% | 824 |
+
+The CPU worker approaches one fully occupied core during the slowdown and
+underruns increase by 46 across those last two intervals. This supports the
+existing CPU/thermal sensitivity diagnosis. It does not isolate a particular
+game function, prove thermal throttling is the sole cause, or attribute the
+entire interval to the screenshot-free scene description. The existing startup
+`Failed to allocate memory space: 0x3` message also occurs in the control build;
+the session continues into gameplay and it is not evidence that this change
+caused the later slowdown.
+
+## Decision
+
+Merge the small normal-loop specialization and the default-off profiling/route
+support as an incremental improvement. The changed loop preserves the original
+execution body and game modules, has passing build/targeted checks, and has
+physical normal-path and diagnostic-path evidence. The earlier native pair
+supports lower loop overhead; neither that pair nor this user run establishes
+a precise FPS improvement. Rejected private math modules are not in the PR.
+No public IPA or physical online-match acceptance is implied by the merge.
+
+## Next logging work
+
+The ten-second FPS and utilization summaries are too coarse to explain short
+stalls. Add low-overhead per-interval frame-time p95/max and missed-frame counts,
+plus interval audio-underrun deltas, using the existing frame boundary. Avoid
+per-dispatch CPU clocks in normal play: their measured observer cost is material.
+A bounded native trace should then target a flagged slow interval in an actual
+owner match. Keep this logging change separate from the already-tested build-17
+merge so the merged implementation matches the physical evidence.
+
+Private raw log SHA-256: `80c9f3c4a2e34f239e813becc40b3dd47e2121ea904a32eb23c7ba58f3589de2`.
+The raw log stays under ignored `ref/revision-102/performance-loop/build17-owner/`.

--- a/patches/moderngekko-dolphin/0056-static-recomp-normal-loop.patch
+++ b/patches/moderngekko-dolphin/0056-static-recomp-normal-loop.patch
@@ -1,0 +1,57 @@
+diff --git a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h b/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h
+--- a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h
++++ b/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore.h
+@@ -103,6 +103,8 @@
+   const char* GetName() const override { return "StaticRecomp"; }
+ 
+ private:
++  template <bool Diagnostics>
++  void RunWithDiagnostics();
+   // JitBaseBlockCache with no generated blocks; exists so generic
+   // icache-invalidation plumbing in JitInterface has a real object to talk
+   // to, and to feed every invalidation into the SMC demotion guard (D4).
+diff --git a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore_Run.cpp b/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore_Run.cpp
+--- a/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore_Run.cpp
++++ b/Source/Core/Core/PowerPC/StaticRecomp/StaticRecompCore_Run.cpp
+@@ -56,20 +56,34 @@
+ 
+ void StaticRecompCore::Run()
+ {
++  const bool diagnostics = Common::FramePhaseTiming::IsEnabled() ||
++      m_lockstep_verifier->IsEnabled() || !m_dispatch_frame_log_path.empty() ||
++      !m_dispatch_time_log_path.empty() || !m_dispatch_burst_log_path.empty() ||
++      std::getenv("STATICRECOMP_DISPATCH_SAMPLE") != nullptr ||
++      std::getenv("STATICRECOMP_FREEZE_TRACE") != nullptr;
++  if (diagnostics)
++    RunWithDiagnostics<true>();
++  else
++    RunWithDiagnostics<false>();
++}
++
++template <bool Diagnostics>
++void StaticRecompCore::RunWithDiagnostics()
++{
+   auto& core_timing = m_system.GetCoreTiming();
+   auto& power_pc = m_system.GetPowerPC();
+   auto& ppc = power_pc.GetPPCState();
+   auto& interpreter = m_system.GetInterpreter();
+   auto& memory = m_system.GetMemory();
+   const CPU::State* state_ptr = m_system.GetCPU().GetStatePtr();
+-  const bool log_phase = Common::FramePhaseTiming::IsEnabled();
+-  const bool lockstep_enabled = m_lockstep_verifier->IsEnabled();
+-  const bool sample_dispatches = !m_dispatch_frame_log_path.empty() ||
++  const bool log_phase = Diagnostics && Common::FramePhaseTiming::IsEnabled();
++  const bool lockstep_enabled = Diagnostics && m_lockstep_verifier->IsEnabled();
++  const bool sample_dispatches = Diagnostics && (!m_dispatch_frame_log_path.empty() ||
+                                  !m_dispatch_time_log_path.empty() ||
+-                                 std::getenv("STATICRECOMP_DISPATCH_SAMPLE") != nullptr;
+-  const bool sample_dispatch_time = !m_dispatch_time_log_path.empty();
+-  const bool sample_dispatch_bursts = !m_dispatch_burst_log_path.empty();
+-  const bool freeze_trace = std::getenv("STATICRECOMP_FREEZE_TRACE") != nullptr;
++                                 std::getenv("STATICRECOMP_DISPATCH_SAMPLE") != nullptr);
++  const bool sample_dispatch_time = Diagnostics && !m_dispatch_time_log_path.empty();
++  const bool sample_dispatch_bursts = Diagnostics && !m_dispatch_burst_log_path.empty();
++  const bool freeze_trace = Diagnostics && std::getenv("STATICRECOMP_FREEZE_TRACE") != nullptr;
+   const bool has_rel_modules = m_module && m_module->num_rel_modules != 0;
+   const u32 idle_pc = m_idle_pc;
+   const u32 secondary_idle_pc = m_secondary_idle_pc;

--- a/scripts/bootstrap-dependencies.sh
+++ b/scripts/bootstrap-dependencies.sh
@@ -385,6 +385,7 @@ apply_patch_once "$MG/vendor/dolphin" "$ROOT/patches/moderngekko-dolphin/0052-ne
 apply_patch_once "$MG/vendor/dolphin" "$ROOT/patches/moderngekko-dolphin/0053-netplay-local-input-trace.patch"
 apply_patch_once "$MG/vendor/dolphin" "$ROOT/patches/moderngekko-dolphin/0054-netplay-boundary-clock-trace.patch"
 apply_patch_once "$MG/vendor/dolphin" "$ROOT/patches/moderngekko-dolphin/0055-netplay-interpreter-fallback.patch"
+apply_patch_once "$MG/vendor/dolphin" "$ROOT/patches/moderngekko-dolphin/0056-static-recomp-normal-loop.patch"
 apply_patch_once "$MG" "$ROOT/patches/moderngekko/0023-melee-revision-selection.patch"
 apply_patch_once_or_marker "$MG" "$ROOT/patches/moderngekko/0024-revision-support-netplay-version.patch" \
   tools/netplay_compatibility.cpp \


### PR DESCRIPTION
Normal gameplay still carries disabled diagnostic branches through the static-recomp CPU loop. Compile normal and diagnostic versions of the same execution body so ordinary play avoids that bookkeeping while timing, lockstep, exception handling, and netplay boundaries remain available. Also enable the existing physical benchmark route for verified v1.02 and expose default-off device capture through a developer launch variable.

Physical iPhone build 17 uses unchanged game modules. In a bounded native comparison, loop self samples fell from 1,683 to 980 ms and total CPU-thread samples were 2.38% lower. The owner reports improvement, but the latest gameplay log still contains 41–45 FPS intervals under serious thermal pressure. This is an incremental optimization, not a sustained-60-FPS or online-play claim. The rejected private math candidates are excluded.

Validation: physical iOS Release/core builds; benchmark-route, diagnostics/privacy, idle-policy, lightweight-frame-recorder and dispatch-time checks; patch apply/recount and dependency-bootstrap idempotency; physical normal-path gameplay and diagnostic-path capture. The execution body after mode selection is unchanged. Raw game data and device logs remain private; the repository includes the evidence summary and follow-up logging work.
