### PR TITLE
Shorten README and publish performance resume handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,321 +113,32 @@ signing material, or a generated game module.
 ## FAQ
 
 <details>
-<summary>Is this possible without a completed Melee decompilation?</summary>
-
-Yes. A traditional decompilation reconstructs human-readable source code.
-MeleePad takes a different route: DolRecomp converts the game's existing
-PowerPC instructions into generated code that Apple Clang compiles for ARM64.
-That makes native execution possible without claiming to have recovered the
-game's original source code.
-
-</details>
-
-<details>
-<summary>Is MeleePad truly native on iPhone and iPad?</summary>
-
-Yes, in the platform and execution sense. The installed app and generated game
-module are ARM64 binaries. Rendering uses Metal, and the app uses native Apple
-interfaces for touch, controllers, audio, file import, settings, and lifecycle.
-It does not need a browser or just-in-time compiler.
-
-“Native” does not mean the entire GameCube was rewritten by hand. ModernGekko's
-Dolphin-derived runtime still provides the hardware behavior that Melee expects.
-The most accurate description is a **native static-recompilation compatibility
-port**.
-
-</details>
-
-<details>
-<summary>Is this an emulator?</summary>
-
-MeleePad shares substantial runtime technology with Dolphin for graphics,
-audio, memory, input, and GameCube system behavior. The important difference is
-CPU execution: supported Melee code is converted and compiled ahead of time
-instead of going through Dolphin's normal runtime JIT or interpreter.
-
-It is best understood as a game-specific static recompilation joined to a
-Dolphin-derived compatibility runtime—not a stock Dolphin frontend and not a
-from-scratch source port.
-
-</details>
-
-<details>
-<summary>Does MeleePad need JIT or special runtime permissions?</summary>
-
-No. The game module is compiled to ARM64 before installation, so normal gameplay
-does not generate executable code on the device. A locally installed build still
-needs ordinary Apple development signing, just like other apps run from Xcode.
-
-</details>
-
-<details>
-<summary>Which game revisions and images does MeleePad support?</summary>
-
-Static recompilation depends on the executable's exact instructions, addresses,
-and data. Even legitimate regional or revision releases differ at those
-locations. Preview 4 supports verified USA v1.02 (disc revision 2),
-recommended for new setups, and USA v1.00 (disc revision 0). Each needs its own
-matching native module. Imports and saves remain separate.
-
-See [supported images, hashes, and version tradeoffs](docs/MELEE-VERSIONS.md).
-The catalog accepts specific raw images and the verified v1.02 CISO; it does
-not accept arbitrary compressed or modified images. Renaming a file does not
-make it compatible. v1.01, PAL, and Japanese images remain unsupported.
-
-Preview 4 supports both revisions; older Preview 3/build 7 supported only v1.00.
-
-</details>
-
-<details>
-<summary>Does the repository or app include Melee?</summary>
-
-No. The repository contains no game image, extracted game assets, saves, or
-generated game module. You select your own supported image on first launch.
-MeleePad validates it, keeps a private local copy in the app container, and
-extracts the data the runtime needs. That data stays on your device.
-
-</details>
-
-<details>
 <summary>Can I download a playable IPA?</summary>
 
-No. The [Preview 4 prerelease](https://github.com/chrissotraidis/meleepad/releases/tag/v0.1.0-preview.4)
-includes source and an unsigned, module-free IPA shell for inspection and
-signing-workflow development. It deliberately excludes
-`gGALE01_recomp.dylib`, and `gGALE01r2_recomp.dylib`, so importing an ISO into that IPA cannot make it
-playable.
-
-A playable iPhone or iPad build must be generated locally from your own
-supported disc image on an Apple Silicon Mac, then signed with your Apple
-development account. Start with the [requirements](#requirements), follow the
-[physical-device build steps](#build-for-a-physical-iphone-or-ipad), and finish
-with [first-launch game-data import](#first-launch-on-iphone-or-ipad).
+The public IPA is an unsigned, module-free shell. Importing an ISO alone cannot
+make it playable. Build the matching game module locally and sign the app with
+your Apple development account using the instructions below.
 
 </details>
 
 <details>
-<summary>Does multiplayer work?</summary>
+<summary>Does the completed decompilation make MeleePad faster?</summary>
 
-Experimentally. Preview 4 can create private eight-character room codes through
-Dolphin's public traversal service, and Direct IP remains available. Retained
-Mac/iPad Simulator tests connected and ran synchronized gameplay in both host
-directions.
-
-This is not yet a public multiplayer beta. Physical-device Internet matches,
-independent outside networks, complete cross-platform matches and rematches,
-real-world NAT success, lifecycle recovery, and a production public-game browser
-remain unverified. See [Experimental multiplayer](#experimental-multiplayer) for
-the exact boundary.
+It helps us understand and profile the original game. MeleePad still uses
+statically translated PowerPC code and a Dolphin-derived compatibility runtime;
+the decompilation does not automatically produce an optimized ARM64/Metal port.
+The September 9 investigation retained better scene diagnostics but established
+no reliable gameplay speedup. Heavy iPhone 14 scenes remain a known problem.
 
 </details>
 
 <details>
-<summary>Which Online Play option should I use?</summary>
+<summary>Where are the other answers?</summary>
 
-- **Public Games** is the easiest discovery flow when a supported lobby service
-  is configured. You can see the host, seated players, open seats, room state,
-  freshness, and exact build compatibility before joining. This remains a
-  local development feature; Preview 4 does not ship with a production public
-  browser.
-- **Private Room** is the best current choice for friends. The host creates an
-  eight-character room code and shares it privately. Dolphin's traversal
-  service introduces the devices without exposing the host's IP address in the
-  MeleePad UI.
-- **Direct IP** is an advanced fallback for a trusted local network or private
-  VPN. It exposes the host address, has no relay fallback, and may require UDP
-  port forwarding when used across the internet.
-
-All three modes use MeleePad's experimental fixed-delay gameplay transport.
-They do not connect to Slippi or provide encrypted gameplay.
-
-</details>
-
-<details>
-<summary>Do Private Room players need to be on the same Wi-Fi?</summary>
-
-No. Private Room is specifically the option to test with a trusted player on
-another Internet connection. The host creates an eight-character code and the
-other player enters it. Dolphin's public traversal service introduces the two
-devices, then controller input travels directly between them.
-
-This automatic connection can fail on restrictive routers, cellular or hotel
-networks, and some VPNs because Preview 2 has no relay fallback. For the
-cleanest first test, use ordinary home Wi-Fi on both sides, turn off VPNs, keep
-MeleePad in the foreground, and try switching which player hosts if the first
-attempt fails.
-
-</details>
-
-<details>
-<summary>What should I do if “Creating lobby” takes a long time?</summary>
-
-Give the first attempt a short chance to finish. MeleePad is registering the
-host with Dolphin's public traversal service and waiting for a room code. If
-the room appears, record roughly how long creation took; a delayed success is
-still useful test evidence.
-
-If it does not finish, tap **Cancel**, turn off any VPN, confirm that the device
-has working Internet access, and retry once. Then use **More (•••) → Share
-Diagnostic Logs** and report whether the attempt eventually succeeded. Never
-post the room code or an IP address in a public issue.
-
-</details>
-
-<details>
-<summary>Why are Public Games offline in this build?</summary>
-
-Public Games needs an online MeleePad lobby service. The app cannot safely
-discover strangers by itself: a service must publish and expire rooms, keep
-connection codes hidden until a compatible player joins, limit spam, carry
-room chat, and accept reports.
-
-Preview 4 has no production service address, so the app deliberately fails
-closed. It does not send names, chat, or room information to an unknown server,
-and it does not fall back to an insecure public HTTP endpoint. The development
-service currently stores rooms and reports only in memory and is not suitable
-for public operation.
-
-When Public Games launches, lobby traffic will require HTTPS. That protects the
-directory and chat connection to the lobby service, but it does not encrypt the
-match itself. Gameplay remains a direct peer-to-peer connection. Player names
-are display names, not verified accounts. Until the hosted service and its
-moderation process are ready, use **Private Room** with people you trust.
-
-You can self-host the reference service on a VPS or Zo Computer for staging,
-but it must not be exposed directly. The recommended deployment uses an HTTPS
-edge with DDoS protection, a WAF, and route-level limits in front of an outbound
-tunnel to a loopback-only lobby process. The
-[secure deployment guide](docs/PUBLIC-LOBBY-DEPLOYMENT.md) explains the Zo and
-conventional VPS options and the remaining public-launch gates.
-For the first isolated hosted proof, use the
-[DigitalOcean lobby runbook](docs/PUBLIC-LOBBY-DIGITALOCEAN.md).
-
-</details>
-
-<details>
-<summary>How do player names and room chat work?</summary>
-
-MeleePad asks you to confirm the display name other players will see before
-connecting. The confirmed name is saved on that device. It is not an account,
-a verified identity, or included in exported diagnostic logs.
-
-Preview 4 build 18 shows **Room Chat** after a Private Room or Direct IP
-session connects. Members can type messages up to 160 characters. These
-messages use Dolphin's existing peer gameplay connection, not a MeleePad lobby
-server. They are plaintext like the gameplay traffic, kept only in a small
-in-memory history, and disappear when the session closes. Use these modes only
-with people you trust. Preview 2 build 5 does not have this peer-chat UI.
-
-The development Public Games mode has a separate chat path. Its messages are
-relayed by the configured lobby service, rate limited, and visible only to
-current room members. Public chat provides Hide and Report controls. Those
-controls are intentionally absent from trusted-friend Private Room and Direct
-IP sessions.
-
-Neither path writes message text to MeleePad diagnostics. Public Games remains
-a development implementation, not production anonymous chat. Deployment still
-requires durable moderation records, a published support and abuse contact,
-and an operated response process.
-
-</details>
-
-<details>
-<summary>What happens after an online match ends?</summary>
-
-If Melee is still running, everyone stays in the same synchronized game and
-naturally moves from results back to character select. Players can keep playing
-without finding or joining the room again. The public directory keeps that room
-marked **In match** so new players cannot enter midway through the session.
-
-If the synchronized runtime ends normally, MeleePad returns the public room to
-its waiting state and reopens the connected screen. The same group can chat,
-ready up, and start again. During play, **More (•••) → Experimental Multiplayer**
-shows the current players and room chat. **Return to Game** keeps the connection,
-while **Leave Session** disconnects and removes the player's public presence.
-
-</details>
-
-<details>
-<summary>Can one lobby service support MeleePad, KartPad, and future games?</summary>
-
-Yes, for discovery. The open Pad Lobby Protocol gives every app its own product
-ID and keeps its rooms separate. MeleePad can only browse and join MeleePad
-rooms. A small cross-game activity section may show anonymous totals such as
-KartPad's open rooms, games in progress, and player count, but not names, chat,
-room IDs, connection codes, or IP addresses.
-
-The gameplay layer is not shared. MeleePad keeps its ModernGekko netplay path,
-KartPad keeps its own online transport, and each future game needs a small
-directory adapter plus its own compatibility rules. KartPad is planned as the
-second proof, not implemented in this MeleePad pass.
-
-</details>
-
-<details>
-<summary>Why won't Direct IP connect?</summary>
-
-Check these in order:
-
-1. Both players use the same MeleePad version/build and the supported `GALE01`
-   game revision, matching modules, and matching game data.
-2. The host keeps MeleePad open, chooses **Host**, and listens on UDP port
-   `2626`; the guest chooses **Join** and enters the host's reachable address
-   and the same port.
-3. On a local network, both devices are on the same trusted network and local
-   network access is allowed.
-4. Across the internet, the host's router and firewall allow UDP `2626`, or both
-   players use a trusted private VPN. Carrier-grade NAT and some firewalls may
-   make direct hosting impossible.
-
-Direct IP has no traversal or relay fallback. If the network cannot accept the
-incoming peer, changing the input buffer will not fix discovery. Prefer a
-Private Room unless you specifically need Direct IP for controlled testing.
-
-</details>
-
-<details>
-<summary>Does online play support four players?</summary>
-
-The development Public Games lobby now supports two-, three-, and four-seat
-rooms, and clearly shows who is seated and which spots are open. That is the
-lobby experience, not proof of a four-player match.
-
-MeleePad's retained gameplay evidence still covers two connected endpoints.
-Four-player gameplay needs explicit protocol, controller-slot, host-loss,
-disconnect, latency, and physical-device testing before it can be called
-working. Treat four-seat rooms as development UI until that gate passes.
-
-</details>
-
-<details>
-<summary>Why doesn't Slippi work with MeleePad?</summary>
-
-No. Slippi is not a service that MeleePad can simply turn on. It combines
-extensive injected game code, a customized Dolphin
-runtime, rollback networking, accounts, and private matchmaking services.
-
-MeleePad supports v1.02 and v1.00 in Preview 4 and uses its own
-fixed-delay protocol. Sharing the v1.02 target does not make it Slippi-compatible.
-Slippi supports Melee v1.02 and expects Slippi's game modifications and network
-protocol. The two systems are not compatible, so MeleePad users cannot join the
-normal Slippi player pool. Supporting that would require a major separate port
-and cooperation from Project Slippi; it is not planned for MeleePad.
-
-</details>
-
-<details>
-<summary>What works on a physical iPhone or iPad today?</summary>
-
-The game launches and plays on a physical iPad with Metal rendering, touch
-controls, supported physical controllers, persistent game data and saves, and
-the native settings menu. One observed solo run held close to 60 FPS at 2x
-resolution; another later run sustained 46–57 FPS under serious thermal
-pressure after an extended in-game pause.
-
-Serious water, reflection, and shadow rendering defects remain, and the full
-device acceptance matrix is still in progress. Physical-device online play has
-not passed its release gates.
+The [full FAQ](docs/FAQ.md) covers native execution, JIT, supported images,
+controllers, multiplayer, privacy, connection troubleshooting, Slippi, and
+physical-device limitations. The [Online Play guide](docs/ONLINE-PLAY.md)
+contains setup instructions, verified results, and remaining acceptance gates.
 
 </details>
 
@@ -437,7 +148,7 @@ not passed its release gates.
 |---|---|---|
 | macOS | Native Apple Silicon launcher and runner, Metal rendering, keyboard and controller profiles, matches, saves, and settings | Final display and worst-frame acceptance work remains |
 | iPhone and iPad | Native app shell, Metal gameplay, touch controls, controller mapping, More menu, exact-image import, persistent saves and settings, and diagnostic export | Serious water, reflection, and shadow rendering defects remain; the full visual, audio, controller, and lifecycle matrix has not passed |
-| Performance | A physical iPad can hold 59.9–60.0 FPS/VPS at 2x resolution during observed solo play | Preview 1 can fall to 46–57 FPS in heavier scenes under thermal pressure; results are scene- and device-specific |
+| Performance | A physical iPad can hold 59.9–60.0 FPS/VPS at 2x resolution during observed solo play | Latest iPhone 14 logs include 37.9–45.6 FPS dips and audio starvation; sustained heavy-scene performance remains unresolved |
 | Experimental multiplayer | Preview 4 fixed-delay Private Room and Direct IP transport, eight-character room codes, temporary peer chat, native Host/Join lobby, compatibility fingerprinting, and synchronized Mac/iPad Simulator runs in both host directions | No public matchmaking endpoint, physical-device/outside-network/full-match beta evidence, relay, or Slippi rollback |
 | Distribution | Preview 4 source plus an unsigned, module-free IPA shell; locally generated, locally signed playable apps | Public IPA is not playable as downloaded; no App Store or TestFlight build; the locally generated game module is not distributed |
 
@@ -450,6 +161,16 @@ acceptance rows, and known rendering debt are tracked in
 The accepted Preview 1 performance debt and the retained physical-device
 measurements are summarized in
 [the physical-iPad thermal slowdown record](docs/artifacts/2026-09-03/preview1-physical-ipad-thermal-slowdown.md).
+
+## Development handoff
+
+The September 9 performance session is stopped. Private build 20 adds scene
+logging with the stable game modules; the matrix optimization candidate was not
+promoted. **No new release or proven gameplay speedup resulted.**
+
+Start with the [resume handoff](docs/SESSION-HANDOFF-2026-09-09.md) for preserved
+builds, findings, and the next bounded investigation. Research code is preserved
+on `codex/decomp-connected-performance`; it is separate from the public release.
 
 ## Requirements
 
@@ -580,170 +301,27 @@ physical-controller profiles are preserved.
 
 ## Experimental multiplayer
 
-> [!WARNING]
-> **Online play is not ready for general use.** Preview 4 contains experimental
-> private rooms and Direct IP. Its Public Games interface has passed local
-> development testing, but no production public-game service is deployed.
-> Build 7 includes peer chat in Private Room and Direct IP for controlled tests.
+Private Room and Direct IP are available for controlled tests with people you
+trust. Both peers need the **same app build, game revision, matching modules and
+game data, and compatible gameplay settings**. For the published Preview 4,
+that means build 18 on both ends; USA v1.02 is recommended. v1.00 can only play
+with a compatible v1.00 peer. Private diagnostic builds are not the release.
 
-| Available now | Not available yet |
+| Option | Current boundary |
 |---|---|
-| Private eight-character room codes | Production public-game browser |
-| Direct IP for advanced testing | Automatic or ranked matchmaking |
-| Temporary peer chat in Preview 4 build 18 | Moderated public chat service |
-| Two-player Mac/iPad Simulator evidence | Verified four-player online rooms |
-| Physical-iPad room creation | Physical-device completed Internet matches |
-| Compatibility checks and desync shutdown | Relay fallback or encrypted gameplay |
-| Native Host, Join, Ready, and Start flow | General multiplayer-beta evidence |
+| Private Room | Eight-character room codes through Dolphin traversal; no relay fallback |
+| Direct IP | Advanced testing on a trusted network or private VPN |
+| Public Games | Development UI only; no production public browser |
+| Room Chat | Temporary plaintext peer chat in Private Room and Direct IP |
 
-### What a player can test now
+Retained tests include synchronized Mac/iPad Simulator runs. A completed
+physical iPhone/iPad Internet match has **not** passed acceptance. There is no
+Slippi rollback, ranked matchmaking, encrypted gameplay, or verified four-player
+online release.
 
-1. Arrange a game with another MeleePad player outside the app.
-2. Confirm that both players use the same build, the exact supported `GALE01`
-   game revision, modules, and matching gameplay settings. Both peers must use
-   Preview 4/build 18 and the same game revision (v1.02 recommended).
-   Older Preview 3 builds are incompatible with this version.
-3. The host opens **More (•••) → Online Play → Private Room → Host**.
-4. After the app displays an eight-character room code, the host sends it to
-   the other player through a trusted channel.
-5. The guest opens **Private Room → Join**, enters that code, and connects.
-6. Send one Room Chat message in each direction, then verify the compatibility
-   state, mark Ready, and let the host start the match.
-
-This flow depends on Dolphin's public traversal service. There is no in-app
-list of strangers to play in the shipped configuration.
-
-Players do not need the same public IP address or Wi-Fi network. In fact, the
-most useful community test places the two players on independent networks.
-Follow the [Private Room community test guide](docs/PRIVATE-ROOM-TESTING.md) and
-report the complete result, including slow or failed attempts.
-
-### Safety and privacy today
-
-- Play only with people you trust.
-- A room code helps two devices find each other. It is not a password, identity
-  check, or encryption key.
-- Gameplay and Private Room or Direct IP chat travel directly between peers and
-  are currently plaintext.
-- Some routers and firewalls will reject a connection because there is no relay
-  fallback.
-- Exported diagnostics should never include full IP addresses, room codes, game
-  data, saves, or signing material.
-
-<details>
-<summary>How does Preview 4 connect the players?</summary>
-
-- Both players run the match locally; MeleePad exchanges synchronized
-  controller input rather than streaming video.
-- Both devices need the same MeleePad build, supported game revision, module,
-  and compatible settings.
-- The transport uses fixed delay. It is not Slippi rollback netcode.
-- Gameplay is peer-to-peer over ENet after traversal introduction. MeleePad
-  does not host the match or stream the game.
-- There is no relay fallback. Some NAT or firewall combinations may fail even
-  when the room code resolves.
-- The joining player is assigned another GameCube controller port.
-- A synchronization mismatch stops the session instead of allowing the two
-  games to continue in different states.
-
-</details>
-
-### What has been verified
-
-| Test | Result |
-|---|---|
-| Two Macs using direct connection | One full match completed through results and lobby return, with saves unchanged |
-| Mac and iPad direct connection | Clean rebuilt peers sustained synchronized execution in both host directions beyond the old failure point |
-| iPhone multiplayer interaction | Compile coverage only; no completed device match |
-| Public Internet room code | Dolphin's live traversal service created/resolved fresh codes; Mac/iPad Simulator sustained about 4,700 rendered frames in each host direction |
-| Physical iPad room creation | Preview 2 build 5 reached `Internet room is ready` and received a room code; no remote peer joined, so this is not match or P2P acceptance |
-| Private/Direct peer chat | Build 7 includes the build-6 two-way host/join runtime coverage; its Private Room composer is visible on the physical iPad, but a two-device physical exchange remains unverified |
-| Public room discovery | Local lobby service discovered a live Mac traversal host and authorized an iPad Simulator join; production service is not deployed |
-
-The earlier Mac/iPad canonical failure was stale-build contamination and did
-not reproduce after clean rebuilds; no timing tolerance or RAM exclusion was
-used. The stronger full-match and real-network acceptance work continues in
-the [multiplayer goal loop](docs/NETPLAY-BETA-GOAL-LOOP.md).
-
-### Private Room, Public Games, and Direct IP
-
-- **Private Room** is the working Internet-room preview. Players arrange a game
-  elsewhere and exchange an ephemeral room code privately. Current `main`
-  build 18 includes temporary chat over the same peer connection.
-- **Public Games** is the planned discovery layer. Its native UI can show
-  compatible room cards and supports bounded room chat, Hide, and Report in
-  local development tests. No production endpoint is deployed.
-- **Direct IP** bypasses discovery and traversal. It is intended for local
-  networks and advanced testing. Build 7 exposes the same peer-chat composer
-  after the direct session connects.
-
-The public browser is designed so room listings never reveal traversal codes.
-Only an authorized, compatible Join response discloses the connection code.
-Release builds fail closed when no production service is configured.
-
-<details>
-<summary>How does Direct IP work, and when should I use it?</summary>
-
-Use Direct IP for controlled testing on a trusted local network or private VPN:
-
-1. The host chooses **Host**, keeps UDP port **2626**, and creates the lobby.
-2. The host shares an IP address or hostname reachable by the joining device.
-3. The second player chooses **Join**, enters that address and the same port,
-   then connects.
-4. Both players mark themselves **Ready**; the host starts the synchronized
-   session.
-
-UDP port 2626 is Dolphin's standard direct-netplay listening port. It is not a
-MeleePad server. Same-network testing normally requires no router change;
-testing across the public internet may require UDP port forwarding or a private
-VPN. The current gameplay channel is plaintext, so use it only with trusted
-people on a private test network. Do not expose it as a public service.
-
-</details>
-
-Local service and Simulator instructions are in
-[services/lobby/README.md](services/lobby/README.md). The remaining discovery,
-moderation, and deployment gates are in the
-[public lobby goal loop](docs/PUBLIC-LOBBY-GOAL-LOOP.md). The reusable,
-multi-game directory boundary and MeleePad-first implementation sequence are in
-the [Pad Lobby Protocol goal loop](docs/PAD-LOBBY-PROTOCOL-GOAL-LOOP.md).
-
-### Plan after Preview 4
-
-The next-preview plan is deliberately staged:
-
-1. run bounded Private Room community tests on Preview 4 build 18,
-   beginning with trusted two-player pairs on independent networks and a chat
-   message in each direction;
-2. finish full matches on physical Apple devices across independent networks,
-   including NAT, disconnect, backgrounding, save, input, audio, and thermal
-   coverage;
-3. use the connection-success, latency, desync, and rematch evidence as the
-   go/no-go gate for further public-lobby work;
-4. only after that gate passes, deploy a supported HTTPS staging discovery
-   service with durable moderation, rate limits, monitoring, retention
-   deletion, and rollback; and
-5. freeze one version/build/protocol tuple for the next preview, keeping Public
-   Games disabled if either gameplay or service acceptance is incomplete.
-
-The detailed gates and stop rules are in the
-[public lobby goal loop](docs/PUBLIC-LOBBY-GOAL-LOOP.md).
-
-<details>
-<summary>What must pass before this can be called a beta?</summary>
-
-Before the UI can be called **Online Play with Friends (Beta)**, one unchanged
-build must complete full Mac/iPad, Mac/iPhone, and iPad/iPhone matches; pass
-disconnect, backgrounding, save, input, performance, and privacy checks; and
-connect across separate networks through a working short room-code flow. The
-[multiplayer beta plan](docs/NETPLAY-BETA-GOAL-LOOP.md) defines the complete
-acceptance matrix.
-
-Four-player online play has additional gates: four stable controller slots,
-four-seat room state, coordinated match start, peer-loss behavior, latency and
-buffer policy, full-match determinism, and physical-device thermal testing.
-
-</details>
+For setup, troubleshooting, privacy, and the full test history, see the
+[Online Play guide](docs/ONLINE-PLAY.md). Use the
+[Private Room test guide](docs/PRIVATE-ROOM-TESTING.md) for a complete report.
 
 ## Reporting issues
 

--- a/docs/DECOMP-PERFORMANCE-GOAL-LOOP.md
+++ b/docs/DECOMP-PERFORMANCE-GOAL-LOOP.md
@@ -1,0 +1,282 @@
+# Decompilation-informed performance loop
+
+Started 2026-09-09. Budget: approximately three hours of investigation, implementation,
+and validation, as requested by the owner. Baseline: Preview 4/build 18, main
+`83b81ed2416c0d64fc36556289dbffe4af306a0a`.
+
+## Outcome
+
+The investigation produced a reproducible local-register optimization for three
+matrix routines and a verified native-to-decompiled-source attribution tool.
+The final private candidate passes 79,000 synthetic/adversarial comparisons and
+300 additional comparisons sampled during actual Classic combat. Its isolated
+host timings are promising. After the owner unlocked the iPhone, an A–B–A–B
+physical comparison produced lower late-window frame times for both candidate
+runs, but did not establish a sufficiently controlled gameplay benefit.
+**The candidate is not promoted to normal builds.** Build 18 is restored on
+the iPhone; build 19 and the reproducible experiment remain private research.
+
+The bounded pass is complete with an evidence-backed decision against shipping
+this candidate yet. No public release, merge, or general FPS claim follows.
+The next target is identifying and profiling the expensive late scene, with
+scene boundaries recorded independently of menu-input steps.
+
+## Working loop
+
+1. Attribute existing native samples to exact decompiled functions. Generated
+   16 KiB chunk names are not game-function names. Distinguish animation, graphics
+   matrix submission, collision, and scalar math before choosing a connected region.
+2. Estimate attainable whole-thread coverage, including boundary/guard overhead.
+   Read the decompiled callers and existing runtime correctness constraints.
+3. Implement one reversible, revision-specific candidate. Preserve intermediate
+   rounding, guest memory and register state, exceptions, cycle accounting and
+   fallback behavior. Do not trade simulation accuracy for speed.
+4. Compare against the unchanged module with adversarial state/memory tests.
+   Only then build/install on the physical iPhone and compare heavy scenes at
+   1x/4:3, including a warmed repeat and frame/audio tails. Internal dispatch
+   timing stays off for native profiling and acceptance runs.
+5. Keep only a repeatable whole-game improvement. Record a failed experiment
+   once, then move only if the evidence supports a distinct target. Stop around
+   the time budget instead of extending an inconclusive benchmark campaign.
+
+## Boundaries
+
+Preserve the stable release, v1.00 support, existing device images/saves/settings,
+and unrelated images in the worktree. Use a separate branch and private artifacts
+under `ref/revision-102/decomp-connected/`. No public release is requested in this
+pass. No Simulator netplay or QuickTime recording. Physical netplay acceptance
+remains a separate requirement; numerical equivalence tests do not establish it.
+
+Do not repeat the rejected inverse/trig/scalar leaf rewrites, global FP-check
+removal, or FIFO sleep-threshold changes without materially new evidence. The
+earlier [performance ledger](IPHONE-102-PERFORMANCE-GOAL-LOOP.md) remains authoritative.
+
+## Evidence ledger
+
+- Goal created and branch `codex/decomp-connected-performance` opened. Both
+  physical iPhone and iPad are available. No candidate installed yet.
+- Existing clean native profile identifies generated bodies, helper calls and
+  runtime costs, but the matrix-labelled chunk spans multiple unrelated functions.
+  First task: resolve native sample offsets to source before selecting a region.
+- Rebuilt source-line information for 16 selected generated chunks. The resulting
+  module's complete 81,323,120-byte executable section, addresses, constants and
+  unwind section match the shipped module. This permits attribution of the saved
+  physical profiles without changing the sampled workload. The private analyzer
+  resolves inline-helper call sites as well as direct generated instruction lines;
+  unresolved samples remain explicitly unassigned.
+- Across two captures, the mapped matrix concatenation cost is about 4.8–4.9%
+  of CPU-thread samples, inverse-transpose about 3.9–4.1%, and matrix writers
+  about 7.4–7.9%. These are source-attributed samples, including work charged
+  once to the nearest mapped caller, not predicted savings. About 52–54% of
+  the full CPU thread is mapped by this selected-chunk pass. Main joint-matrix
+  construction is much smaller than its broad chunk name suggested.
+- Candidate 1: partition five hot matrix functions at decompilation-verified
+  boundaries into separate native functions. Preserve their translated bodies,
+  all helper calls, and the original return-dispatch budget/exception behavior.
+  This tests compiler optimization within smaller functions rather than another
+  math-formula replacement or broad compiler-flag sweep. Private iOS module
+  compilation/linking passed. Rejected before device installation: 100,000
+  full-state/RAM/ordered-MMIO comparisons passed, but isolated timing was flat
+  or slightly worse. Smaller functions alone did not remove the relevant work.
+- Candidate 2: retain floating-point register lanes and status in local native
+  state across matrix concatenation, inverse-transpose and scaled-add, then
+  commit architectural state at the original return boundary. Arithmetic and
+  paired-single bit conversions retain the existing runtime semantics. Guards
+  require ordinary bounded finite matrices, supported memory/FP modes and
+  safe aliases; all other cases execute the unchanged translated body.
+  This is a private prototype, not a retained release change.
+- The complete candidate module passes 30,000 randomized/adversarial
+  full-state/RAM/MMIO comparisons, another 30,000 continuation/interior-entry
+  comparisons, and 9,000 additional alias/FP edge comparisons. Original ABI,
+  code ranges, SMC ranges and source-chunk metadata match the control.
+  Initial missing-constant and NaN-payload failures were caught locally and
+  led to stricter guards before these passing runs. These tests establish
+  the tested behavior, not universal equivalence or netplay acceptance.
+- Isolated full-module host measurements: concatenation roughly 140–151 ns
+  to 50–54 ns; inverse-transpose 350–354 ns to 260–268 ns; scaled-add
+  104–110 ns to 64–66 ns. Applying those reductions to the old physical
+  sample shares gives an optimistic ceiling around 5% of CPU-thread time.
+  This assumes comparable device code generation and sufficient guard hits;
+  it is neither measured iPhone savings nor an FPS prediction.
+- Before the phone was unlocked, private build 19 was staged and signature-verified. The host machine-code
+  section and v1.00 module are unchanged; only the v1.02 candidate and private
+  bundle version differ. The initial physical control launch was rejected by
+  the lock screen. That earlier block was resolved by the owner unlocking
+  the phone; see the physical comparison below.
+- A separate, isolated local opening-sequence run observed approximately 99.997%
+  concatenation, 95.8% inverse-transpose and 99.9998% scaled-add guard acceptance
+  among calls entering through the module dispatcher. It compared 100 live
+  input states per routine against the full original module, including all
+  24 MiB of guest RAM and CPU state; those 300 comparisons passed. The test
+  used Null graphics/audio, so it provides guard/correctness evidence only.
+  Internal same-chunk entries are not counted by that diagnostic wrapper.
+  The first run was initially mislabeled Classic: source scene IDs identify
+  `0x18` as the opening movie and `0x03` as Classic. Timed input began before
+  the controller pipe connected and missed the Start presses. The revised
+  diagnostic drives menus from observed scene IDs; opening hit rates must not
+  be presented as combat coverage.
+- A subsequent review adds one conservative fallback: a concatenation stack
+  frame must not overlap the constant table. Otherwise a saved incoming FP
+  register could overwrite the table after its entry check. Both modules
+  rebuilt successfully; all 69,000 full-state, continuation and alias cases
+  pass again. That intermediate build remained uninstalled and was superseded
+  by the final arithmetic-input guard below.
+- Reading `HSD_MtxInverseTranspose` identified unnecessary checks on the
+  previous destination and input translation slots. Its arithmetic uses only
+  the input 3x3 block; the original copy/continuation paths remain intact.
+  Restricting the finite-value guard to actual arithmetic inputs passes all
+  69,000 earlier cases plus 10,000 cases with arbitrary unused-slot and
+  destination contents. Both complete modules rebuild successfully.
+- The corrected local route reaches Classic state `0x03030101`. The pinned
+  `gm_Mode_Classic_States` maps state 1 to `GS_VS`, confirming the gameplay
+  phase rather than inferring it from elapsed time. A further 100 comparisons
+  per routine, after 300,000 eligible calls in that phase, pass against the
+  original module with complete CPU state and 24 MiB RAM equality. In the
+  preceding complete route, final guards accepted over 99.99% of observed
+  dispatcher entries for all three routines. This remains a local Null-renderer
+  correctness/coverage check, not iPhone or netplay acceptance.
+- Final isolated host timing ranges: concatenation control 142–184 ns versus
+  candidate 51–53 ns (the control warms across rounds); inverse-transpose
+  352–358 ns versus 257–265 ns; scaled-add 104–107 ns versus 64–66 ns.
+  Keep the roughly 5% optimistic CPU-time projection separate from measured
+  whole-game benefit, which remains unknown.
+- Reuse investigation: 100,000 consecutive inverse-call input records from
+  Classic gameplay show 51.0% reuse in a 128-entry LRU and 60.0% in 256 entries
+  with the full observed key. Keeping only arithmetic inputs plus FPSCR gives
+  54.0% and 61.9%; increasing capacity to 1,024 adds no hits in this sample.
+  This does not justify adding a broad cache now: inverse-transpose is only
+  about 4% of the old CPU profile, and even ideal reuse leaves a small ceiling
+  before lookup, key construction and architectural-state restoration costs.
+  No result cache was implemented or enabled.
+
+## What the decompilation changes
+
+The recovered source provides function boundaries, data layouts and the exact
+inputs each calculation uses. This pass used all three: to attribute native
+costs, preserve return/exception behavior, and remove unnecessary guard checks.
+That is a concrete use of the decompilation in the implementation.
+
+It is still a GameCube-targeted codebase. For example, the upstream
+[`PSMTXConcat` implementation](https://github.com/doldecomp/melee/blob/ae5898ee0dfda41b34fdf846f7d680a33e14779d/extern/dolphin/src/dolphin/mtx/mtx.c#L136)
+contains PowerPC assembly. MeleePad's current native module translates such
+operations while maintaining guest registers, memory, floating-point behavior
+and the hardware interface. Source completion does not remove that work.
+
+Locally, the original DOL has 3,882,272 bytes of executable sections; the
+baseline native module has 81,323,120 bytes of executable code including
+translation and compatibility helpers. This size comparison illustrates the
+different representation; it does not establish a cache bottleneck or a speed
+ratio. A broader native-source port would also need to resolve guest pointer
+layouts, endianness, SDK/hardware calls and cross-boundary state semantics.
+
+The immediate next step is to validate this candidate on the iPhone. If it
+fails that gate, retain the attribution tooling and reject the runtime change;
+do not respond by layering more matrix microbenchmarks onto it.
+
+## Reusable research tools
+
+`scripts/analyze-native-guest-cost.py` replaces broad chunk-name guesses with
+source attribution for exported arm64 Time Profiler CPU samples. It checks the
+sampled module UUID, equivalent debug module's complete `__TEXT` sections and
+addresses, and matching dSYM UUID. It resolves direct lines and inline-helper
+call sites, adjusts caller return PCs, and charges each sample once. Functions
+with identical names at different guest addresses remain separate. Unmapped
+work stays in the denominator. Six synthetic tests and a replay of the saved
+physical profile pass; the latter reproduces 52.06% mapped CPU coverage.
+
+Use the exact generated source tree from the debug build: DWARF v4 does not
+authenticate source contents. The script's binary checks do not remove that
+precondition. For example, with paths to private local artifacts:
+
+```sh
+python3 scripts/analyze-native-guest-cost.py \
+  --trace-xml "$TRACE_XML" --baseline "$SAMPLED_MODULE" \
+  --debug-module "$EQUIVALENT_DEBUG_MODULE" --dsym "$MATCHING_DSYM" \
+  --generated "$MATCHING_GENERATED_CHUNKS" --symbols "$DECOMP_SYMBOLS" \
+  --output "$PRIVATE_REPORT"
+```
+
+`scripts/prepare-matrix-local-state-experiment.py` makes the candidate
+reproducible without committing game-derived bodies. It authenticates seven
+input files against the tested v1.02 source/runtime hashes, refuses an existing
+output directory, and writes only private generated sources and an experiment
+manifest. Unsupported revisions or changed runtime semantics fail before any
+output is created. Three synthetic input/preservation tests pass. Regeneration
+of the initial candidate reproduced all five source files byte for byte.
+The final guarded candidate also reproduces all five files byte for byte.
+The experiment is not wired into normal builds, installation or releases.
+
+```sh
+python3 scripts/prepare-matrix-local-state-experiment.py \
+  --generated "$MATCHING_GENERATED_ROOT" --runtime "$MATCHING_GXRUNTIME" \
+  --output "$FRESH_PRIVATE_EXPERIMENT_DIR"
+```
+
+Compile its two replacement chunks plus `lift.c` using the original module's
+flags and link against the unchanged other objects. In particular, preserve
+floating-point contraction/fast-math settings, ABI and revision checks. The
+generated output includes game-derived code and must stay private.
+
+## Physical comparison and retention decision
+
+The unlocked physical iPhone ran build 18, build 19, build 18, build 19 in that
+order on 2026-09-09. Each fixed four-player Big Blue route used v1.02, 1x,
+4:3, the normal CPU clock and disabled per-dispatch diagnostics. Every run
+started at nominal thermal state and ended at fair. The app was stopped
+between runs for approximately three minutes. No Simulator, QuickTime or
+computer-use screen observation was used.
+
+The final two ten-second reports of each run give:
+
+| Run | Build | Weighted frame interval | Reported FPS range | Audio underruns |
+| --- | --- | ---: | ---: | ---: |
+| Control A1 | 18 | 31.50 ms | 32.2–32.3 | 203 |
+| Candidate B1 | 19 | 29.22 ms | 34.6–34.7 | 187 |
+| Control A2 | 18 | 33.26 ms | 30.8–31.4 | 167 |
+| Candidate B2 | 19 | 30.25 ms | 33.0–33.4 | 187 |
+
+Both candidate tails were faster than both control tails. This is a useful
+signal, not a defensible general performance percentage: the runs are not
+exact guest-state replays, and baseline timing varies. The first three tails
+share the same projection fingerprint and 111,205 primitives; B2 shares the
+projection but has 111,189 primitives and different earlier graphics work.
+Audio-underrun counts do not consistently improve. Every tail remains far
+below 60 FPS with CPU and video threads near saturation.
+
+Apple Time Profiler reported the phone offline and timed out for all four
+captures, although CoreDevice could launch the app and wired AFC could read
+logs. Therefore there is **no new native CPU-cost or fast-path-hit measurement**.
+The table uses the app's existing lightweight frame/audio logs. Failed
+profiler attempts are disclosed; these were not clean profiler-free launches.
+Startup logs confirm the intended builds, revision and differing module sizes.
+
+The menu route verifies four slots and forces Big Blue, but existing logs stop
+reporting game state after stage selection. The late rendering work rises from
+roughly 34,000 to 111,000 primitives per frame. The decompiled VS mode table
+(`src/melee/gm/gmvsmode.c` at the pinned source revision) distinguishes combat,
+sudden death and results. The current evidence does not identify which late
+scene produced the slowdown; do not label these tail numbers four-fighter
+combat performance.
+
+**Decision:** reject promotion for this release and restore private build 18.
+Keep the candidate and source tooling for a focused follow-up. This rejects
+shipping on insufficient evidence; it does not prove the optimization has no
+benefit. Every installation was in place, with fresh before/after comparisons
+of 24 material files and unchanged ISO size and timestamps. Neither revision's
+saves/configuration nor the ISO was reset. The iPad was untouched.
+
+### Concrete next target
+
+Record scene transitions from the existing revision-aware benchmark state
+reader, independently of input-step changes, at a safe runtime boundary.
+Use the decompiled mode table to isolate combat from results, then establish
+an identical scene/input window. Restore native profiler connectivity before
+attributing the remaining CPU/video saturation. If the expensive tail is
+results, profile its character-model/skin matrix submission separately from
+combat. Only then retry the matrix experiment against a matched window;
+do not restart the rejected global FP, leaf-math or sleep-threshold searches.
+
+Private evidence is under `ref/revision-102/decomp-connected/`: four run folders,
+`physical-pair.json`, the signed candidate receipt and fresh preservation
+backups. Raw device logs, identifiers, game data and generated code remain
+excluded from the repository.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,325 @@
+# MeleePad FAQ
+
+[Back to MeleePad](../README.md) · [Online Play guide](ONLINE-PLAY.md)
+
+
+<details>
+<summary>Is this possible without a completed Melee decompilation?</summary>
+
+Yes. A traditional decompilation reconstructs human-readable source code.
+MeleePad takes a different route: DolRecomp converts the game's existing
+PowerPC instructions into generated code that Apple Clang compiles for ARM64.
+That makes native execution possible without claiming to have recovered the
+game's original source code.
+
+</details>
+
+<details>
+<summary>Is MeleePad truly native on iPhone and iPad?</summary>
+
+Yes, in the platform and execution sense. The installed app and generated game
+module are ARM64 binaries. Rendering uses Metal, and the app uses native Apple
+interfaces for touch, controllers, audio, file import, settings, and lifecycle.
+It does not need a browser or just-in-time compiler.
+
+“Native” does not mean the entire GameCube was rewritten by hand. ModernGekko's
+Dolphin-derived runtime still provides the hardware behavior that Melee expects.
+The most accurate description is a **native static-recompilation compatibility
+port**.
+
+</details>
+
+<details>
+<summary>Is this an emulator?</summary>
+
+MeleePad shares substantial runtime technology with Dolphin for graphics,
+audio, memory, input, and GameCube system behavior. The important difference is
+CPU execution: supported Melee code is converted and compiled ahead of time
+instead of going through Dolphin's normal runtime JIT or interpreter.
+
+It is best understood as a game-specific static recompilation joined to a
+Dolphin-derived compatibility runtime—not a stock Dolphin frontend and not a
+from-scratch source port.
+
+</details>
+
+<details>
+<summary>Does MeleePad need JIT or special runtime permissions?</summary>
+
+No. The game module is compiled to ARM64 before installation, so normal gameplay
+does not generate executable code on the device. A locally installed build still
+needs ordinary Apple development signing, just like other apps run from Xcode.
+
+</details>
+
+<details>
+<summary>Which game revisions and images does MeleePad support?</summary>
+
+Static recompilation depends on the executable's exact instructions, addresses,
+and data. Even legitimate regional or revision releases differ at those
+locations. Preview 4 supports verified USA v1.02 (disc revision 2),
+recommended for new setups, and USA v1.00 (disc revision 0). Each needs its own
+matching native module. Imports and saves remain separate.
+
+See [supported images, hashes, and version tradeoffs](MELEE-VERSIONS.md).
+The catalog accepts specific raw images and the verified v1.02 CISO; it does
+not accept arbitrary compressed or modified images. Renaming a file does not
+make it compatible. v1.01, PAL, and Japanese images remain unsupported.
+
+Preview 4 supports both revisions; older Preview 3/build 7 supported only v1.00.
+
+</details>
+
+<details>
+<summary>Does the repository or app include Melee?</summary>
+
+No. The repository contains no game image, extracted game assets, saves, or
+generated game module. You select your own supported image on first launch.
+MeleePad validates it, keeps a private local copy in the app container, and
+extracts the data the runtime needs. That data stays on your device.
+
+</details>
+
+<details>
+<summary>Can I download a playable IPA?</summary>
+
+No. The [Preview 4 prerelease](https://github.com/chrissotraidis/meleepad/releases/tag/v0.1.0-preview.4)
+includes source and an unsigned, module-free IPA shell for inspection and
+signing-workflow development. It deliberately excludes
+`gGALE01_recomp.dylib`, and `gGALE01r2_recomp.dylib`, so importing an ISO into that IPA cannot make it
+playable.
+
+A playable iPhone or iPad build must be generated locally from your own
+supported disc image on an Apple Silicon Mac, then signed with your Apple
+development account. Start with the [requirements](../README.md#requirements), follow the
+[physical-device build steps](../README.md#build-for-a-physical-iphone-or-ipad), and finish
+with [first-launch game-data import](../README.md#first-launch-on-iphone-or-ipad).
+
+</details>
+
+<details>
+<summary>Does multiplayer work?</summary>
+
+Experimentally. Preview 4 can create private eight-character room codes through
+Dolphin's public traversal service, and Direct IP remains available. Retained
+Mac/iPad Simulator tests connected and ran synchronized gameplay in both host
+directions.
+
+This is not yet a public multiplayer beta. Physical-device Internet matches,
+independent outside networks, complete cross-platform matches and rematches,
+real-world NAT success, lifecycle recovery, and a production public-game browser
+remain unverified. See [Experimental multiplayer](../README.md#experimental-multiplayer) for
+the exact boundary.
+
+</details>
+
+<details>
+<summary>Which Online Play option should I use?</summary>
+
+- **Public Games** is the easiest discovery flow when a supported lobby service
+  is configured. You can see the host, seated players, open seats, room state,
+  freshness, and exact build compatibility before joining. This remains a
+  local development feature; Preview 4 does not ship with a production public
+  browser.
+- **Private Room** is the best current choice for friends. The host creates an
+  eight-character room code and shares it privately. Dolphin's traversal
+  service introduces the devices without exposing the host's IP address in the
+  MeleePad UI.
+- **Direct IP** is an advanced fallback for a trusted local network or private
+  VPN. It exposes the host address, has no relay fallback, and may require UDP
+  port forwarding when used across the internet.
+
+All three modes use MeleePad's experimental fixed-delay gameplay transport.
+They do not connect to Slippi or provide encrypted gameplay.
+
+</details>
+
+<details>
+<summary>Do Private Room players need to be on the same Wi-Fi?</summary>
+
+No. Private Room is specifically the option to test with a trusted player on
+another Internet connection. The host creates an eight-character code and the
+other player enters it. Dolphin's public traversal service introduces the two
+devices, then controller input travels directly between them.
+
+This automatic connection can fail on restrictive routers, cellular or hotel
+networks, and some VPNs because Preview 4 has no relay fallback. For the
+cleanest first test, use ordinary home Wi-Fi on both sides, turn off VPNs, keep
+MeleePad in the foreground, and try switching which player hosts if the first
+attempt fails.
+
+</details>
+
+<details>
+<summary>What should I do if “Creating lobby” takes a long time?</summary>
+
+Give the first attempt a short chance to finish. MeleePad is registering the
+host with Dolphin's public traversal service and waiting for a room code. If
+the room appears, record roughly how long creation took; a delayed success is
+still useful test evidence.
+
+If it does not finish, tap **Cancel**, turn off any VPN, confirm that the device
+has working Internet access, and retry once. Then use **More (•••) → Share
+Diagnostic Logs** and report whether the attempt eventually succeeded. Never
+post the room code or an IP address in a public issue.
+
+</details>
+
+<details>
+<summary>Why are Public Games offline in this build?</summary>
+
+Public Games needs an online MeleePad lobby service. The app cannot safely
+discover strangers by itself: a service must publish and expire rooms, keep
+connection codes hidden until a compatible player joins, limit spam, carry
+room chat, and accept reports.
+
+Preview 4 has no production service address, so the app deliberately fails
+closed. It does not send names, chat, or room information to an unknown server,
+and it does not fall back to an insecure public HTTP endpoint. The development
+service currently stores rooms and reports only in memory and is not suitable
+for public operation.
+
+When Public Games launches, lobby traffic will require HTTPS. That protects the
+directory and chat connection to the lobby service, but it does not encrypt the
+match itself. Gameplay remains a direct peer-to-peer connection. Player names
+are display names, not verified accounts. Until the hosted service and its
+moderation process are ready, use **Private Room** with people you trust.
+
+You can self-host the reference service on a VPS or Zo Computer for staging,
+but it must not be exposed directly. The recommended deployment uses an HTTPS
+edge with DDoS protection, a WAF, and route-level limits in front of an outbound
+tunnel to a loopback-only lobby process. The
+[secure deployment guide](PUBLIC-LOBBY-DEPLOYMENT.md) explains the Zo and
+conventional VPS options and the remaining public-launch gates.
+For the first isolated hosted proof, use the
+[DigitalOcean lobby runbook](PUBLIC-LOBBY-DIGITALOCEAN.md).
+
+</details>
+
+<details>
+<summary>How do player names and room chat work?</summary>
+
+MeleePad asks you to confirm the display name other players will see before
+connecting. The confirmed name is saved on that device. It is not an account,
+a verified identity, or included in exported diagnostic logs.
+
+Preview 4 build 18 shows **Room Chat** after a Private Room or Direct IP
+session connects. Members can type messages up to 160 characters. These
+messages use Dolphin's existing peer gameplay connection, not a MeleePad lobby
+server. They are plaintext like the gameplay traffic, kept only in a small
+in-memory history, and disappear when the session closes. Use these modes only
+with people you trust. Preview 2 build 5 does not have this peer-chat UI.
+
+The development Public Games mode has a separate chat path. Its messages are
+relayed by the configured lobby service, rate limited, and visible only to
+current room members. Public chat provides Hide and Report controls. Those
+controls are intentionally absent from trusted-friend Private Room and Direct
+IP sessions.
+
+Neither path writes message text to MeleePad diagnostics. Public Games remains
+a development implementation, not production anonymous chat. Deployment still
+requires durable moderation records, a published support and abuse contact,
+and an operated response process.
+
+</details>
+
+<details>
+<summary>What happens after an online match ends?</summary>
+
+If Melee is still running, everyone stays in the same synchronized game and
+naturally moves from results back to character select. Players can keep playing
+without finding or joining the room again. The public directory keeps that room
+marked **In match** so new players cannot enter midway through the session.
+
+If the synchronized runtime ends normally, MeleePad returns the public room to
+its waiting state and reopens the connected screen. The same group can chat,
+ready up, and start again. During play, **More (•••) → Experimental Multiplayer**
+shows the current players and room chat. **Return to Game** keeps the connection,
+while **Leave Session** disconnects and removes the player's public presence.
+
+</details>
+
+<details>
+<summary>Can one lobby service support MeleePad, KartPad, and future games?</summary>
+
+Yes, for discovery. The open Pad Lobby Protocol gives every app its own product
+ID and keeps its rooms separate. MeleePad can only browse and join MeleePad
+rooms. A small cross-game activity section may show anonymous totals such as
+KartPad's open rooms, games in progress, and player count, but not names, chat,
+room IDs, connection codes, or IP addresses.
+
+The gameplay layer is not shared. MeleePad keeps its ModernGekko netplay path,
+KartPad keeps its own online transport, and each future game needs a small
+directory adapter plus its own compatibility rules. KartPad is planned as the
+second proof, not implemented in this MeleePad pass.
+
+</details>
+
+<details>
+<summary>Why won't Direct IP connect?</summary>
+
+Check these in order:
+
+1. Both players use the same MeleePad version/build and the supported `GALE01`
+   game revision, matching modules, and matching game data.
+2. The host keeps MeleePad open, chooses **Host**, and listens on UDP port
+   `2626`; the guest chooses **Join** and enters the host's reachable address
+   and the same port.
+3. On a local network, both devices are on the same trusted network and local
+   network access is allowed.
+4. Across the internet, the host's router and firewall allow UDP `2626`, or both
+   players use a trusted private VPN. Carrier-grade NAT and some firewalls may
+   make direct hosting impossible.
+
+Direct IP has no traversal or relay fallback. If the network cannot accept the
+incoming peer, changing the input buffer will not fix discovery. Prefer a
+Private Room unless you specifically need Direct IP for controlled testing.
+
+</details>
+
+<details>
+<summary>Does online play support four players?</summary>
+
+The development Public Games lobby now supports two-, three-, and four-seat
+rooms, and clearly shows who is seated and which spots are open. That is the
+lobby experience, not proof of a four-player match.
+
+MeleePad's retained gameplay evidence still covers two connected endpoints.
+Four-player gameplay needs explicit protocol, controller-slot, host-loss,
+disconnect, latency, and physical-device testing before it can be called
+working. Treat four-seat rooms as development UI until that gate passes.
+
+</details>
+
+<details>
+<summary>Why doesn't Slippi work with MeleePad?</summary>
+
+Slippi is not a service that MeleePad can simply turn on. It combines
+extensive injected game code, a customized Dolphin
+runtime, rollback networking, accounts, and private matchmaking services.
+
+MeleePad supports v1.02 and v1.00 in Preview 4 and uses its own
+fixed-delay protocol. Sharing the v1.02 target does not make it Slippi-compatible.
+Slippi supports Melee v1.02 and expects Slippi's game modifications and network
+protocol. The two systems are not compatible, so MeleePad users cannot join the
+normal Slippi player pool. Supporting that would require a major separate port
+and cooperation from Project Slippi; it is not planned for MeleePad.
+
+</details>
+
+<details>
+<summary>What works on a physical iPhone or iPad today?</summary>
+
+The game launches and plays on physical iPhone and iPad devices with Metal rendering, touch
+controls, supported physical controllers, persistent game data and saves, and
+the native settings menu. One observed solo run held close to 60 FPS at 2x
+resolution; another later run sustained 46–57 FPS under serious thermal
+pressure after an extended in-game pause.
+
+Known water, reflection, and shadow rendering defects remain, and the full
+device acceptance matrix is still in progress. Physical-device online play has
+not passed its release gates. Latest iPhone 14 logs include 37.9–45.6 FPS
+slowdowns and audio starvation. The September 9 follow-up retained diagnostics,
+not a proven speed fix; see the [resume handoff](SESSION-HANDOFF-2026-09-09.md).
+
+</details>

--- a/docs/IPHONE-OWNER-RUN-2026-09-09.md
+++ b/docs/IPHONE-OWNER-RUN-2026-09-09.md
@@ -1,0 +1,95 @@
+# iPhone owner gameplay: 2026-09-09
+
+## Status
+
+The owner's running build 18 was read over wired AFC without launching,
+pausing, replacing or stopping the app. This is fresh manual gameplay evidence,
+separate from the earlier A–B–A–B experiment. The installed game remains v1.02,
+1x, 4:3, normal emulated CPU clock, stable performance profile, low-power mode
+off. No benchmark route or per-dispatch capture was enabled.
+
+The session began at 17:21:43 JST. Two copies retain 84 and then 108 performance
+reports, with the final report at 17:40:28 JST. The DMA underrun counter reached
+340. These are empty-queue events, not 340 seconds of silence or necessarily
+340 individually audible clicks. The raw logs and device identifiers remain
+private under `ref/revision-102/decomp-connected/owner-20260909-173634/`.
+
+## Confirmed slow periods
+
+| Report time (JST) | Reported FPS | Mean frame interval | Thermal state | DMA underrun delta |
+| --- | ---: | ---: | --- | ---: |
+| 17:27:21 | 40.1 | 21.45 ms | fair | 46 |
+| 17:27:31 | 44.1 | 21.64 ms | fair | 45 |
+| 17:27:41 | 37.9 | 25.98 ms | fair | 67 |
+| 17:35:28 | 45.6 | 18.29 ms | serious | 15 |
+| 17:35:38 | 45.5 | 22.37 ms | serious | 49 |
+| 17:35:48 | 51.4 | 22.95 ms | serious | 47 |
+
+Reported FPS/speed and frame-interval summaries have different sampling windows;
+do not invert an instantaneous FPS reading and treat it as the ten-second mean.
+The later three reports contain 111 underruns. CPU-thread utilization was
+94.1%, 98.2% and 97.0%; video-thread utilization was 63.7%, 74.2% and 72.1%.
+One frame reached 54.02 ms in the middle report. The CPU thread is close to its
+available execution budget; this does not identify whether its time is spent
+in game logic, graphics submission, synchronization or other work.
+
+There was also a resign/resume event at 17:33:54–17:33:59. Its following report
+contains 11 underruns and a 77.84 ms maximum. Keep that lifecycle transition
+separate from steady gameplay. The first CPU-usage report after a reset is not
+a valid interval baseline; do not interpret anomalous thread percentages there
+as sustained utilization.
+
+After 17:35:58 the retained reports return to 59.9 FPS and approximately
+16.69 ms mean intervals, without further underruns, while thermal state remains
+serious. This does not prove a fix or sustained combat acceptance: the game
+workload or an in-game pause may have changed. Host `paused=0` does not establish
+that combat is active. Severe dips also occurred at fair thermal state earlier.
+**Thermal pressure is a contributor, not a complete explanation.**
+
+## Hardware context
+
+The connected devices are an iPhone 14 and a 12.9-inch iPad Pro (6th generation).
+Apple specifies an [A15 Bionic in iPhone 14](https://support.apple.com/en-au/111850)
+and an [M2 with a 10-core GPU in that iPad Pro](https://support.apple.com/en-gb/111841).
+The stronger iPad hardware is consistent with the owner's better experience;
+this session is not a controlled cross-device comparison and supplies no
+relative-speed multiplier or measured GPU occupancy.
+
+## Audio-path investigation
+
+The current iOS DMA mixer makes only a small resampling correction, clamped to
+0.98–1.02, to stabilize queue depth. When the DMA queue empties, it increments
+the counter, supplies silence and re-enters prebuffering. See the patched
+Dolphin `Source/Core/AudioCommon/Mixer.cpp`, `MixerFifo::Mix` and `Dequeue`.
+The later slow reports show speed ratios 0.755 and 0.769: roughly a quarter
+below full speed. A two-percent queue correction cannot compensate for a
+sustained producer deficit of that scale. More reserve may hide a short stall,
+but adds latency and cannot restore missing game throughput. A broader audio
+stretching experiment would change audio behavior, not make gameplay faster.
+No buffer, pitch, game-speed or mixer change is retained from this inspection.
+
+## Next implementation boundary
+
+The missing diagnostic is a scene snapshot alongside the existing timing rows,
+including enough transition information to reject mixed-scene comparisons.
+Source-defined mode IDs must distinguish VS combat, sudden death and results.
+Use the pinned decompilation's `src/melee/gm/gmvsmode.c` and the already verified
+revision-specific routing addresses, not projection hashes as scene names.
+
+Do not read live guest RAM unsynchronized from the UI timer or call
+`Core::RunOnCPUThread` for every log sample: that helper calls `PauseAndLock`.
+Instead, capture a small bounded snapshot at the existing CPU-thread
+`Core::OnFrameEnd` boundary, and let the UI consume a synchronized copy. Verify
+revision/start/stop invalidation, unsupported revisions, transition handling
+and logging overhead before deployment. No such runtime patch has been added
+or installed in this pass; this is the concrete implementation plan.
+
+Then profile a confirmed sustained slow combat window, separating CPU game work
+from video submission/waits. Revisit the guarded matrix candidate only in a
+matched scene. It remains unpromoted following the earlier comparison.
+
+## Retained changes
+
+Documentation and private log evidence only. Build 18 stays on the phone;
+ISO, saves, preferences and iPad are untouched. No public release, runtime
+performance change or general iPhone playability claim is made.

--- a/docs/IPHONE-SCENE-PERFORMANCE-GOAL.md
+++ b/docs/IPHONE-SCENE-PERFORMANCE-GOAL.md
@@ -1,0 +1,185 @@
+# iPhone scene performance follow-up
+
+Started 2026-09-09 after the owner's build-18 slowdown report. Aim for a bounded
+approximately two-hour engineering pass, extending only for a running validation.
+The stable baseline remains Preview 4/build 18; the earlier matrix candidate is
+not promoted. Preserve both game revisions, device data and unrelated files.
+
+## Outcome
+
+Complete: retain the nonblocking scene diagnostics and private build 20 with
+unchanged stable game modules. Do not promote the matrix optimization. One
+combat pair narrowly passed the screening threshold, but confirmation failed
+the matched-temperature gate and baseline variation remained material. The
+phone is returned to build 20; the iPad and public release are unchanged.
+
+This pass improves diagnosis, not proven iPhone FPS. Combat and results are now
+separated in actual device logs, and one source-supported candidate has a
+bounded, documented non-promotion decision.
+
+## Plan executed
+
+1. Add revision-aware scene snapshots at the existing CPU frame boundary.
+   Publish bounded synchronized data for the existing ten-second performance
+   log; do not pause the CPU, read guest memory from UI code, write per-frame
+   files or enable per-dispatch profiling. Include transition counts so a
+   sample covering multiple scenes cannot be mistaken for one scene.
+2. Test supported/unsupported revisions, initial validity, transitions, reset,
+   coherent reads and overhead. Build the physical-device app using unchanged
+   stable game modules. Establish identity and preserve data on installation.
+3. Capture an identified slow scene on the attached iPhone. Distinguish VS
+   combat, sudden death, results, menu and unknown states. Attempt native
+   profiling only when connectivity is available; no Simulator or QuickTime.
+4. Select one optimization justified by the scene/profile evidence. Compare
+   matched workload, settings and starting temperature with the stable control.
+   Retain only repeatable frame-time benefit without correctness/audio regression.
+   Otherwise document rejection and the exact next target. No automatic release.
+
+Progress and evidence will be appended here. Instrumentation is not an FPS fix.
+
+## First implementation
+
+Patch 0058 adds a single CPU-frame producer and a synchronized snapshot read by
+the existing ten-second log. A producer uses `try_lock` and skips contention;
+it does not wait, allocate, read the clock, write logs or pause the CPU. Guest
+RAM is read only on the CPU thread. The snapshot includes validity, revision,
+routing word, session, sampled-frame count and scene-transition count. Pending
+and previous mode bytes do not count as actual scene transitions. Unreadable
+state invalidates the sample; recovery counts as a transition for conservative
+mixed-window rejection. Unsupported revisions disable sampling.
+
+The runtime-scoped session resets before boot and after runtime destruction,
+including create failures and early exits. The labels distinguish source-defined
+VS character selection, stage selection, combat, sudden death and results;
+other modes remain conservatively labeled. A combat label does not prove the
+in-game pause menu is closed. Comparing session/frame/transition counters across
+reports is required; one scene name does not identify the whole preceding window.
+
+The standalone patch-extraction test exercises revision addresses, validity,
+resets, transitions, invalid reads, contended producer skipping and concurrent
+snapshot reads. Bootstrap verifies the complete patch series. Physical core and
+Release app builds pass. An isolated host recorder benchmark measured 5.0–5.5 ns
+per uncontended call with a synthetic read callback; this excludes actual guest
+memory reads and is not physical-device overhead acceptance.
+
+Private build 20 contains diagnostics with byte-identical build 18 modules for
+both revisions. It was installed in place after a fresh backup; all 24 material
+files and the ISO metadata match afterward. The iPad was untouched. A fixed
+four-player Big Blue route is now validating scene identity without native or
+per-dispatch profiling. No speed improvement is claimed.
+
+## Physical scene validation
+
+Build 20's first four-minute route successfully reports source-defined scene
+changes. Its unchanged-module combat samples show 51–54 FPS, serious thermal
+pressure and approximately 99% CPU-thread usage with a constant transition count.
+The late 111,205-primitive projection is now positively identified as
+`vs-results`, routing `02020104`; its final two reports are 28.3–28.4 FPS at
+serious thermal pressure. Thus earlier unclassified matrix-experiment tails
+must not be called combat improvements. Exact earlier state cannot be recovered
+retroactively, but the matching late workload in this route is results.
+
+This first run began thermally serious and is scene validation, not a fair
+speed comparison with earlier nominal-start baselines. CoreDevice and AFC work;
+Instruments still lists both devices offline. One separate run of the existing
+phase/dispatch-time profiler is collecting ranking evidence. Its overhead is
+explicitly excluded from performance acceptance. Combat is the first target;
+results remain a separate performance issue.
+
+## Optimization selection from combat-only profiling
+
+The separate existing profiler captured 6,439 phase rows and 230,851 dispatch
+samples inside unchanged-session/transition VS-combat windows, excluding 250 ms
+at each wall-clock boundary. Calibrated dispatch samples rank PSMTXConcat 7.79%,
+HSD_MtxInverseTranspose 5.25% and HSD_MtxScaledAdd 2.46% of sampled guest time.
+Those are sample shares, not whole-app or GPU savings; profiling overhead and
+clock calibration affect them. Estimated sampled dispatch coverage is about
+71% of recorded CPU-thread time, and native Instruments profiling remains
+unavailable. Individual sampled dispatch timings can include host scheduling
+and do not replace native stack attribution.
+
+This new scene-specific evidence justifies one focused retry of the previously
+validated guarded matrix candidate. Private build 21 will combine the identical
+build 20 host/diagnostics with the previously tested v1.02 module. Both normal
+runs will disable detailed capture. Evaluate unchanged-transition combat
+windows separately from results, with matched settings and thermal state;
+repeat only if the first pair is promising. The route is not an exact saved-state
+replay, so modest changes within workload/run variation remain inconclusive.
+
+Acceptance screen set before the candidate run: use consecutive reports that
+both identify valid VS combat with identical session and transition counts,
+with sampled scene-frame boundaries fully inside 3,500–9,000. Compare weighted
+mean frame intervals, fraction over 20 ms and underruns per observed second.
+A first pair must improve mean intervals by at least 5% without worse slow-frame
+fraction or materially worse audio starvation (more than 10% per second) to
+justify a repeat. Both runs must start in the same reported thermal state.
+Repeat a promising pair; reject promotion if it does not reproduce or if
+workload differences prevent a defensible comparison. This is a screening
+criterion, not statistical proof of a general FPS gain.
+
+## First combat comparison
+
+The predeclared window filter yields nine ten-second combat reports for each
+build. Build 20: 18.030 ms weighted mean, 8.37% over 20 ms, 139 underruns (1.54/s).
+Build 21: 17.125 ms, 1.14% over 20 ms, 53 underruns (0.59/s). The mean reduction is
+5.02%, narrowly passing the screen. Both started serious, but the candidate
+briefly became fair; its sampled primitive range also fell to about 25,854
+versus 32,460 minimum in the control. Those confounds prevent promotion from
+this pair alone. One reverse control and one candidate repeat will decide this
+pass; no additional candidate or open-ended testing is planned.
+
+## Other leads checked without adding experiments
+
+The boot allocation warning has a plausible optional-cache origin: the static
+core initializes an `EmptyBlockCache` derived from `JitBaseBlockCache`, whose
+base initializer attempts a large lazy entry-point map and permits a null
+result. This is not evidence of a new sustained combat bottleneck; no memory
+mapping or cache option was changed.
+
+The older retained native control profile also shows substantial video-thread
+CPU time in `FifoManager::RunGpuLoop` and `SetCPStatusFromGPU`. That suggests a
+future measurement separating useful command processing from polling/waiting,
+not another blind FIFO sleep-threshold change (those were already rejected).
+These are older native samples and are not newly attributed to this run's
+combat window. Shader/vertex-decoder changes likewise need current cost evidence.
+
+## Final comparison and decision
+
+| Run | Build | Start thermal | Combat mean | Frames over 20 ms | Underruns/s |
+| --- | --- | --- | ---: | ---: | ---: |
+| Control A1 | 20 | serious | 18.030 ms | 8.37% | 1.54 |
+| Candidate B1 | 21 | serious | 17.125 ms | 1.14% | 0.59 |
+| Control A2 | 20 | fair | 17.640 ms | 4.04% | 1.09 |
+| Candidate B2 | 21 | nominal | excluded | excluded | excluded |
+
+A2 used nine eligible ten-second combat windows. B2's nominal start failed the
+predeclared matching condition against A2's fair start. Its driver and exact
+app process were stopped, and its partial log retained as an invalid run.
+It was not substituted into the acceptance table or counted as a confirmation.
+The first pair's candidate had both a cooler thermal interval and some lower
+rendering workload. There is therefore no repeatable causal improvement strong
+enough to promote. No additional run or candidate was added to this pass.
+
+Build 20 was reinstalled in place and its normal startup checked. All 24 backed-up
+material files and ISO metadata match before/after the final installation.
+The v1.00 and v1.02 game modules remain byte-identical to stable build 18.
+The normal runtime is stopped after verification so it does not keep heating
+the phone. Build 21 remains a private, unpromoted experiment.
+
+### Next focused work
+
+Use scene-aware logs from real play to select a sustained combat case. Before
+another small matrix A/B, establish a reproducible initial game-state/input
+fixture and a matching thermal start; the existing route is not an exact replay.
+For a potentially larger engine improvement, measure useful video command
+processing separately from FIFO/status polling in that same confirmed scene.
+The previous native sample points to that boundary, but does not prove how much
+current combat CPU time is avoidable. Do not repeat blind sleep-threshold or
+leaf-math changes. Restoring native profiler connectivity remains useful, while
+existing instrumented dispatch ranking must stay separate from speed acceptance.
+
+Private evidence: `ref/revision-102/scene-followup/` contains all run logs,
+profile CSVs and analysis, comparison JSON, packages and preservation checks.
+The implementation is reproducible through patch 0058 and
+`python3 scripts/test_gameplay_scene_snapshot.py`. No game-derived code, game
+assets, raw logs or device identifiers were added to Git; no release was made.

--- a/docs/ONLINE-PLAY.md
+++ b/docs/ONLINE-PLAY.md
@@ -1,0 +1,169 @@
+# Experimental Online Play
+
+[Back to MeleePad](../README.md) · [FAQ](FAQ.md)
+
+
+> [!WARNING]
+> **Online play is not ready for general use.** Preview 4 contains experimental
+> private rooms and Direct IP. Its Public Games interface has passed local
+> development testing, but no production public-game service is deployed.
+> Preview 4 includes peer chat in Private Room and Direct IP for controlled tests.
+
+| Available now | Not available yet |
+|---|---|
+| Private eight-character room codes | Production public-game browser |
+| Direct IP for advanced testing | Automatic or ranked matchmaking |
+| Temporary peer chat in Preview 4 build 18 | Moderated public chat service |
+| Two-player Mac/iPad Simulator evidence | Verified four-player online rooms |
+| Physical-iPad room creation | Physical-device completed Internet matches |
+| Compatibility checks and desync shutdown | Relay fallback or encrypted gameplay |
+| Native Host, Join, Ready, and Start flow | General multiplayer-beta evidence |
+
+### What a player can test now
+
+1. Arrange a game with another MeleePad player outside the app.
+2. Confirm that both players use the same build, the exact supported `GALE01`
+   game revision, modules, and matching gameplay settings. Both peers must use
+   Preview 4/build 18 and the same game revision (v1.02 recommended).
+   Older Preview 3 builds are incompatible with this version.
+3. The host opens **More (•••) → Online Play → Private Room → Host**.
+4. After the app displays an eight-character room code, the host sends it to
+   the other player through a trusted channel.
+5. The guest opens **Private Room → Join**, enters that code, and connects.
+6. Send one Room Chat message in each direction, then verify the compatibility
+   state, mark Ready, and let the host start the match.
+
+This flow depends on Dolphin's public traversal service. There is no in-app
+list of strangers to play in the shipped configuration.
+
+Players do not need the same public IP address or Wi-Fi network. In fact, the
+most useful community test places the two players on independent networks.
+Follow the [Private Room community test guide](PRIVATE-ROOM-TESTING.md) and
+report the complete result, including slow or failed attempts.
+
+### Safety and privacy today
+
+- Play only with people you trust.
+- A room code helps two devices find each other. It is not a password, identity
+  check, or encryption key.
+- Gameplay and Private Room or Direct IP chat travel directly between peers and
+  are currently plaintext.
+- Some routers and firewalls will reject a connection because there is no relay
+  fallback.
+- Exported diagnostics should never include full IP addresses, room codes, game
+  data, saves, or signing material.
+
+<details>
+<summary>How does Preview 4 connect the players?</summary>
+
+- Both players run the match locally; MeleePad exchanges synchronized
+  controller input rather than streaming video.
+- Both devices need the same MeleePad build, supported game revision, module,
+  and compatible settings.
+- The transport uses fixed delay. It is not Slippi rollback netcode.
+- Gameplay is peer-to-peer over ENet after traversal introduction. MeleePad
+  does not host the match or stream the game.
+- There is no relay fallback. Some NAT or firewall combinations may fail even
+  when the room code resolves.
+- The joining player is assigned another GameCube controller port.
+- A synchronization mismatch stops the session instead of allowing the two
+  games to continue in different states.
+
+</details>
+
+### What has been verified
+
+| Test | Result |
+|---|---|
+| Two Macs using direct connection | One full match completed through results and lobby return, with saves unchanged |
+| Mac and iPad Simulator direct connection | Clean rebuilt peers sustained synchronized execution in both host directions beyond the old failure point |
+| iPhone multiplayer interaction | Compile coverage only; no completed device match |
+| Public Internet room code | Dolphin's live traversal service created/resolved fresh codes; Mac/iPad Simulator sustained about 4,700 rendered frames in each host direction |
+| Physical iPad room creation | Preview 2 build 5 reached `Internet room is ready` and received a room code; no remote peer joined, so this is not match or P2P acceptance |
+| Private/Direct peer chat | Build 7 includes the build-6 two-way host/join runtime coverage; its Private Room composer is visible on the physical iPad, but a two-device physical exchange remains unverified |
+| Public room discovery | Local lobby service discovered a live Mac traversal host and authorized an iPad Simulator join; production service is not deployed |
+
+The earlier Mac/iPad canonical failure was stale-build contamination and did
+not reproduce after clean rebuilds; no timing tolerance or RAM exclusion was
+used. The stronger full-match and real-network acceptance work continues in
+the [multiplayer goal loop](NETPLAY-BETA-GOAL-LOOP.md).
+
+### Private Room, Public Games, and Direct IP
+
+- **Private Room** is the working Internet-room preview. Players arrange a game
+  elsewhere and exchange an ephemeral room code privately. Current `main`
+  build 18 includes temporary chat over the same peer connection.
+- **Public Games** is the planned discovery layer. Its native UI can show
+  compatible room cards and supports bounded room chat, Hide, and Report in
+  local development tests. No production endpoint is deployed.
+- **Direct IP** bypasses discovery and traversal. It is intended for local
+  networks and advanced testing. Preview 4 exposes the same peer-chat composer
+  after the direct session connects.
+
+The public browser is designed so room listings never reveal traversal codes.
+Only an authorized, compatible Join response discloses the connection code.
+Release builds fail closed when no production service is configured.
+
+<details>
+<summary>How does Direct IP work, and when should I use it?</summary>
+
+Use Direct IP for controlled testing on a trusted local network or private VPN:
+
+1. The host chooses **Host**, keeps UDP port **2626**, and creates the lobby.
+2. The host shares an IP address or hostname reachable by the joining device.
+3. The second player chooses **Join**, enters that address and the same port,
+   then connects.
+4. Both players mark themselves **Ready**; the host starts the synchronized
+   session.
+
+UDP port 2626 is Dolphin's standard direct-netplay listening port. It is not a
+MeleePad server. Same-network testing normally requires no router change;
+testing across the public internet may require UDP port forwarding or a private
+VPN. The current gameplay channel is plaintext, so use it only with trusted
+people on a private test network. Do not expose it as a public service.
+
+</details>
+
+Local service and Simulator instructions are in
+[services/lobby/README.md](../services/lobby/README.md). The remaining discovery,
+moderation, and deployment gates are in the
+[public lobby goal loop](PUBLIC-LOBBY-GOAL-LOOP.md). The reusable,
+multi-game directory boundary and MeleePad-first implementation sequence are in
+the [Pad Lobby Protocol goal loop](PAD-LOBBY-PROTOCOL-GOAL-LOOP.md).
+
+### Plan after Preview 4
+
+The next-preview plan is deliberately staged:
+
+1. run bounded Private Room community tests on Preview 4 build 18,
+   beginning with trusted two-player pairs on independent networks and a chat
+   message in each direction;
+2. finish full matches on physical Apple devices across independent networks,
+   including NAT, disconnect, backgrounding, save, input, audio, and thermal
+   coverage;
+3. use the connection-success, latency, desync, and rematch evidence as the
+   go/no-go gate for further public-lobby work;
+4. only after that gate passes, deploy a supported HTTPS staging discovery
+   service with durable moderation, rate limits, monitoring, retention
+   deletion, and rollback; and
+5. freeze one version/build/protocol tuple for the next preview, keeping Public
+   Games disabled if either gameplay or service acceptance is incomplete.
+
+The detailed gates and stop rules are in the
+[public lobby goal loop](PUBLIC-LOBBY-GOAL-LOOP.md).
+
+<details>
+<summary>What must pass before this can be called a beta?</summary>
+
+Before the UI can be called **Online Play with Friends (Beta)**, one unchanged
+build must complete full Mac/iPad, Mac/iPhone, and iPad/iPhone matches; pass
+disconnect, backgrounding, save, input, performance, and privacy checks; and
+connect across separate networks through a working short room-code flow. The
+[multiplayer beta plan](NETPLAY-BETA-GOAL-LOOP.md) defines the complete
+acceptance matrix.
+
+Four-player online play has additional gates: four stable controller slots,
+four-seat room state, coordinated match start, peer-loss behavior, latency and
+buffer policy, full-match determinism, and physical-device thermal testing.
+
+</details>

--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -1,5 +1,27 @@
 # meleepad performance ledger
 
+The [scene-aware follow-up](IPHONE-SCENE-PERFORMANCE-GOAL.md) retains private
+build 20 diagnostics with unchanged stable game modules. It confirms combat
+slowdown separately from the very expensive VS-results tail. The matrix retry
+is not promoted: its first pair's apparent 5.02% mean improvement did not obtain
+a valid matched-temperature confirmation. There is no new proven FPS gain.
+
+Fresh [owner gameplay logs](IPHONE-OWNER-RUN-2026-09-09.md) reproduce the iPhone
+problem on restored build 18: 37.9–45.6 FPS dips, CPU-thread saturation and
+340 DMA empty-queue events. Hardware/thermal constraints contribute, but scene
+workload remains unresolved. The report separates lifecycle stalls and audio
+queue limits from sustained gameplay and records the safe next diagnostic step.
+
+The 2026-09-09 [decompilation-informed investigation](DECOMP-PERFORMANCE-GOAL-LOOP.md)
+starts from Preview 4/build 18. Exact native-to-source attribution now identifies
+matrix work across generated chunks. A local-register prototype is promising
+in host tests. An unlocked physical A–B–A–B check showed lower candidate
+late-window frame times (29.22/30.25 ms versus 31.50/33.26 ms), but workload
+variation, inconsistent audio results and failed native profiling prevent
+promotion. Build 18 is restored; no new general gameplay-speed claim is retained.
+The source-attribution and pinned experiment-preparation scripts are reusable;
+neither enables an experimental module in ordinary builds.
+
 G5 is active. G4 passed with a clean controlled 1v1 on 2026-08-24.
 
 PERF-287 attributes and reverses a new ordinary 54.2 FPS / 54.3 VPS / 0.917

--- a/docs/SESSION-HANDOFF-2026-09-09.md
+++ b/docs/SESSION-HANDOFF-2026-09-09.md
@@ -1,0 +1,82 @@
+# Session handoff — September 9, 2026
+
+Work is stopped for today at the owner's request. There is no active goal.
+This follow-up did **not establish a reliable gameplay performance improvement**.
+Do not present the diagnostics or an isolated favorable comparison as a speed fix.
+
+## Preserved state
+
+- Branch: `codex/decomp-connected-performance`. Research code and commits are preserved on this remote branch. The
+  documentation handoff is published separately to main; the experimental code
+  is not merged. No new public IPA or release was made during this follow-up.
+- Stable baseline: Preview 4/build 18, main commit `83b81ed`.
+- iPhone: private build 20, with the unchanged stable v1.00/v1.02 game modules
+  and new scene diagnostics. Final in-place restoration and normal startup were
+  verified, then the app was stopped for cooldown. Selected game: v1.02, 1x, 4:3.
+- Preservation checks matched 24 material save/configuration files and unchanged
+  ISO size/timestamps. Do not reinstall destructively or replace game data.
+- iPad was untouched in this follow-up; its last recorded build is 18.
+- Private matrix candidate builds 19 and 21 are **not promoted**.
+- Three existing untracked Online Play images under `docs/images/` are unrelated
+  to this investigation and remain untouched.
+
+Implementation is in `43e9123` (scene diagnostics); findings are in `eb5032a`.
+Earlier experiment/history commits are `c4d5c72`, `19b45e5`, and `c0a1759`.
+
+## What we learned
+
+The owner's logs confirm real slowdowns and audio starvation, including
+37.9–45.6 FPS reports. Thermal pressure contributes, but does not explain every
+slow interval. Increasing the audio buffer cannot fix sustained execution below
+game speed.
+
+Build 20 adds nonblocking scene snapshots at CPU frame boundaries. These
+distinguish combat from results without pausing the CPU for routine sampling.
+The exceptionally heavy late workload in the new run was **the results screen**;
+older unclassified measurements must not be described as proven combat results.
+Diagnostics passed focused concurrency/lifecycle tests, patch verification,
+device compilation, signing verification, and physical startup/log checks.
+
+Scene-filtered profiling identifies matrix functions as meaningful guest costs,
+but profiling itself adds overhead. One normal combat comparison of candidate 21
+showed a 5.02% lower mean frame interval; thermal and workload differences, and
+an invalid-temperature repeat, prevented confirmation. Candidate 21 was rejected
+for promotion and build 20 restored. Correctness tests and faster host arithmetic
+do not establish a sustained iPhone speedup.
+
+The decompilation recovers original GameCube behavior. It does not automatically
+replace MeleePad's translated PowerPC execution, floating-point state handling,
+or Dolphin-derived graphics/audio layers with optimized Apple-native code.
+Those remaining costs need measured attribution before another implementation.
+
+## Resume later — bounded next step
+
+1. Read the [scene investigation](IPHONE-SCENE-PERFORMANCE-GOAL.md) and
+   [owner-run review](IPHONE-OWNER-RUN-2026-09-09.md). Verify the current checkout
+   and installed build before assuming today's state still holds.
+2. Establish a repeatable, demonstrably unpaused combat fixture with matching
+   thermal starts. A combat routing label alone does not prove unpaused play.
+3. Measure useful video command processing versus FIFO/status polling in that
+   fixture before choosing one larger engine optimization. Existing video-thread
+   samples are older evidence, not current attribution. Native Instruments
+   connectivity failed even though CoreDevice/AFC worked.
+
+Stop the next experiment if it cannot produce comparable physical measurements;
+record that limit instead of continuing broad sweeps. Do not repeat rejected
+math or FIFO sleep-threshold sweeps, promote build 21 from one favorable pair,
+or run multiple simulators. Hardware tests should use the attached devices.
+
+## Evidence locations
+
+- [Detailed scene protocol, results, and acceptance limits](IPHONE-SCENE-PERFORMANCE-GOAL.md)
+- [Earlier decompilation experiment](DECOMP-PERFORMANCE-GOAL-LOOP.md)
+- [Performance notes](PERF.md) and [technical debt](TECH-DEBT.md)
+- Private, ignored directory: `ref/revision-102/scene-followup/` contains
+  `HANDOFF.md`, retained build 20 `MeleePad.app`, unpromoted `matrix/MeleePad.app`,
+  normal startup receipts, preservation comparisons, run logs,
+  `combat-comparison.json`, and `profile-analysis.json`.
+- Earlier private owner logs/candidates: `ref/revision-102/decomp-connected/`.
+
+Keep private game modules, disc images, saves, device identifiers, and signing
+material out of commits and public artifacts. No further run is scheduled by
+this handoff.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,5 +1,16 @@
 # meleepad status
 
+## 2026-09-09 — performance session paused; documentation published
+
+The public release remains Preview 4/build 18. Private iPhone build 20 retains
+scene-aware diagnostics with the stable game modules; matrix candidate 21 was
+not promoted. This follow-up established no reliable gameplay speedup. Heavy
+iPhone 14 scenes and audio starvation remain open. The iPad was unchanged.
+
+The research branch is preserved separately from main. See the
+[resume handoff](SESSION-HANDOFF-2026-09-09.md) for exact commits, evidence,
+build state, and bounded next steps. No goal is active and no new IPA is released.
+
 ## 2026-09-05 — Preview 3 build 7 release
 
 Preview 3 packages the current experimental Private Room and Direct IP flows,

--- a/docs/TECH-DEBT.md
+++ b/docs/TECH-DEBT.md
@@ -1,8 +1,11 @@
 # meleepad technical debt
 
-Last updated: 2026-09-08
+Last updated: 2026-09-09
 
-This is the short, ranked engineering queue behind the active goal loop. It is
+Session stopped for today; no active goal. Start with the
+[September 9 handoff](SESSION-HANDOFF-2026-09-09.md) when resuming.
+
+This is the short, ranked engineering queue for future work. It is
 not a substitute for `GOAL-LOOP.md` or evidence in `docs/artifacts/`.
 
 Performance evidence: [v1.02 iPhone performance goal](IPHONE-102-PERFORMANCE-GOAL-LOOP.md).
@@ -10,7 +13,61 @@ Preview 4/build 18 rolls up the merged build-17 increment and lightweight
 gameplay timing logs.
 Sustained performance and physical netplay limitations remain open.
 
-## Current performance investigation — private build 17
+## Completed scene-aware follow-up
+
+The [bounded scene-aware goal](IPHONE-SCENE-PERFORMANCE-GOAL.md) retains
+nonblocking CPU-frame diagnostics in private build 20, with both stable build 18
+game modules unchanged. Actual logs separate VS combat slowdown from the much
+heavier results screen. The older unclassified tails are not combat acceptance.
+
+A combat-only matrix pair improved its mean by 5.02%, but thermal/workload
+confounds and an invalid-temperature confirmation prevented promotion. The
+phone is returned to diagnostic build 20; the matrix candidate remains private.
+No proven general FPS gain or public release follows. Next establish a repeatable
+combat fixture with matching temperature, and measure useful video processing
+versus FIFO/status polling before choosing a larger engine change.
+
+## Earlier owner gameplay — build 18
+
+The [2026-09-09 manual iPhone log review](IPHONE-OWNER-RUN-2026-09-09.md)
+confirms 37.9–45.6 FPS dips and 340 DMA empty-queue events across the retained
+session. The latest slow cluster has CPU-thread utilization of 94–98% and
+serious thermal pressure, but earlier dips also occur at fair thermal state.
+Later 60 FPS reports while still serious prevent attributing everything to heat.
+
+The audio queue's ±2% correction cannot cover a sustained roughly 25% game-speed
+deficit. Do not treat a larger buffer as a performance fix. Next capture
+revision-aware scene snapshots at the CPU frame boundary; the convenient
+`RunOnCPUThread` helper pauses execution and is unsuitable for routine sampling.
+The report records the implementation boundary and remaining validation.
+No runtime patch or new build was installed during this owner-run inspection.
+
+## Earlier decompilation investigation — after Preview 4
+
+The [bounded decompilation loop](DECOMP-PERFORMANCE-GOAL-LOOP.md) now maps saved
+native samples to exact source functions, using a debug rebuild whose machine
+code matches the sampled module. Matrix concatenation and inverse-transpose
+account for roughly 4.8–4.9% and 3.9–4.1% of CPU-thread samples respectively.
+Splitting functions alone passed correctness checks but offered no useful
+timing improvement and was rejected.
+
+A guarded local-floating-point-state prototype is faster in isolated host
+measurements and passes 79,000 full-module adversarial comparisons plus 300
+comparisons sampled during confirmed local Classic combat. Source-defined
+input guards admit over 99.99% of observed entries in the final local route.
+This uses Null graphics for correctness and coverage, not device speed.
+A physical A–B–A–B comparison then found lower candidate tail frame times,
+but audio did not consistently improve, the repeated workload differed and
+native profiling failed. Build 19 is not promoted; build 18 is restored on the
+iPhone. No public release was made. See the linked loop for the complete table.
+
+Next: log source-defined scene transitions independently of menu input steps,
+identify the late jump to approximately 111,000 primitives per frame, and
+profile an identical scene window. Distinguish combat from results before
+claiming a four-fighter speedup. Preserve the reproducible matrix candidate
+for that focused comparison; do not repeat broad optimization sweeps.
+
+## Earlier performance investigation — private build 17
 
 Build 17 adds a modest host-loop optimization:
 normal execution compiles out disabled diagnostic branches, while timing,


### PR DESCRIPTION
The README repeated extensive FAQ and multiplayer material and the latest performance handoff existed only locally. This reduces the front page from 808 to 386 lines, preserves the full answers in linked FAQ and Online Play guides, and publishes the September 9 findings and resume instructions.

Status, performance notes, and technical debt now distinguish public Preview 4/build 18 from private diagnostic build 20 and the unpromoted matrix experiment. There is no new performance claim, app change, or IPA release. Research code is preserved separately on `codex/decomp-connected-performance` and is not included in this docs-only PR.

Validation: all 69 local documentation links/anchors and expandable-section pairing passed; `git diff --check` passed. The repository suite passed its initial Python/source checks and input/route tests, then stopped because this isolated documentation checkout has no private dependency headers (`InputCommon/ControllerInterface/ControllerInterface.h`). No application code changed.
